### PR TITLE
Revise trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
+  "Framework :: OpenTelemetry",
+  "Framework :: OpenTelemetry :: Distros",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
Add one trove classifier for each of the supported python versions and the OpenTelemetry one.

Fix #36 