### PR TITLE
ci: use a fixed version for build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: pip install build<2
+      - run: pip install build==1.2.1
 
       - run: python -m build
 


### PR DESCRIPTION
## What does this pull request do?

That should help the ci to don't consider it as stderr redirection :)
See https://github.com/elastic/elastic-otel-python/actions/runs/9351266378/job/25736593116#step:3:6

## Related issues

None