### PR TITLE
ci: remove checkout action from publish-pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,6 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
-
       - uses: actions/download-artifact@v4
         with:
           name: packages


### PR DESCRIPTION
## What does this pull request do?

It's currently failing and it doesn't seem we need it
See
https://github.com/elastic/elastic-otel-python/actions/runs/9365036037/job/25780543397