### PR TITLE
[docs] Update the official name of the distribution 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Elastic Distribution for OpenTelemetry Python Changelog
+# Elastic Distribution of OpenTelemetry Python Changelog
 
 ## v0.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to the Elastic Distribution for OpenTelemetry Python
+# Contributing to the Elastic Distribution of OpenTelemetry Python
 
-The Elastic Distribution for OpenTelemetry Python is open source and we love to receive contributions from our community — you!
+The Elastic Distribution of OpenTelemetry Python is open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute,
 from writing tutorials or blog posts,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# elastic-opentelemetry -- Elastic Distribution for OpenTelemetry Python
+# elastic-opentelemetry -- Elastic Distribution of OpenTelemetry Python
 
-`elastic-opentelemetry` is the Elastic Distribution for OpenTelemetry Python.
+`elastic-opentelemetry` is the Elastic Distribution of OpenTelemetry Python.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 maintainers = [
     {name = "Riccardo Magliocchetti", email = "riccardo.magliocchetti@elastic.co"},
 ]
-description = "Elastic Distribution for OpenTelemetry Python"
+description = "Elastic Distribution of OpenTelemetry Python"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
Updates the official name of the distribution from "Elastic Distribution for OpenTelemetry" to "Elastic Distribution of OpenTelemetry". 