### PR TITLE
docs: cite configuration to enable logs exporting

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -39,7 +39,6 @@ EDOT Python supports all configuration options listed in the [OpenTelemetry Gene
 Exporting logs from the Python `logging` module is disabled by default and gated under a configuration environment variable:
 
 ```sh
-export OTEL_LOGS_EXPORTER=otlp
 export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 ```
 
@@ -50,6 +49,7 @@ EDOT Python uses different defaults than OpenTelemetry Python for the following 
 | Option | EDOT Python default | OpenTelemetry Python default |
 |---|---|---|
 | `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | `process_runtime,os,otel,telemetry_distro` | `otel` |
+| `OTEL_LOGS_EXPORTER` | `otlp` | |
 
 ### Configuration options that are _only_ available in EDOT Python
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -49,7 +49,7 @@ EDOT Python uses different defaults than OpenTelemetry Python for the following 
 | Option | EDOT Python default | OpenTelemetry Python default |
 |---|---|---|
 | `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | `process_runtime,os,otel,telemetry_distro` | `otel` |
-| `OTEL_LOGS_EXPORTER` | `otlp` | |
+| `OTEL_LOGS_EXPORTER` | `otlp` | _no default_ |
 
 ### Configuration options that are _only_ available in EDOT Python
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -34,12 +34,21 @@ Because the Elastic Distribution of OpenTelemetry Python is an extension of Open
 
 EDOT Python supports all configuration options listed in the [OpenTelemetry General SDK Configuration documentation](https://opentelemetry.io/docs/languages/sdk-configuration/general/) and [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python).
 
+#### Logs
+
+Exporting logs from the Python `logging` module is disabled by default and gated under a configuration environment variable:
+
+```sh
+export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+```
+
+#### Differences from OpenTelemetry Python
+
 EDOT Python uses different defaults than OpenTelemetry Python for the following configuration options:
 
 | Option | EDOT Python default | OpenTelemetry Python default |
 |---|---|---|
 | `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | `process_runtime,os,otel,telemetry_distro` | `otel` |
-
 
 ### Configuration options that are _only_ available in EDOT Python
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -39,6 +39,7 @@ EDOT Python supports all configuration options listed in the [OpenTelemetry Gene
 Exporting logs from the Python `logging` module is disabled by default and gated under a configuration environment variable:
 
 ```sh
+export OTEL_LOGS_EXPORTER=otlp
 export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 ```
 

--- a/src/elasticotel/distro/__init__.py
+++ b/src/elasticotel/distro/__init__.py
@@ -18,6 +18,7 @@ import os
 from logging import getLogger
 
 from opentelemetry.environment_variables import (
+    OTEL_LOGS_EXPORTER,
     OTEL_METRICS_EXPORTER,
     OTEL_TRACES_EXPORTER,
 )
@@ -72,5 +73,6 @@ class ElasticOpenTelemetryDistro(BaseDistro):
     def _configure(self, **kwargs):
         os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp")
         os.environ.setdefault(OTEL_METRICS_EXPORTER, "otlp")
+        os.environ.setdefault(OTEL_LOGS_EXPORTER, "otlp")
         os.environ.setdefault(OTEL_EXPORTER_OTLP_PROTOCOL, "grpc")
         os.environ.setdefault(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS, "process_runtime,os,otel,telemetry_distro")

--- a/tests/distro/test_distro.py
+++ b/tests/distro/test_distro.py
@@ -20,6 +20,7 @@ from unittest import TestCase, mock
 from elasticotel.distro import ElasticOpenTelemetryDistro
 from elasticotel.distro.environment_variables import ELASTIC_OTEL_SYSTEM_METRICS_ENABLED
 from opentelemetry.environment_variables import (
+    OTEL_LOGS_EXPORTER,
     OTEL_METRICS_EXPORTER,
     OTEL_TRACES_EXPORTER,
 )
@@ -36,6 +37,7 @@ class TestDistribution(TestCase):
         distro.configure()
         self.assertEqual("otlp", os.environ.get(OTEL_TRACES_EXPORTER))
         self.assertEqual("otlp", os.environ.get(OTEL_METRICS_EXPORTER))
+        self.assertEqual("otlp", os.environ.get(OTEL_LOGS_EXPORTER))
         self.assertEqual("grpc", os.environ.get(OTEL_EXPORTER_OTLP_PROTOCOL))
         self.assertEqual(
             "process_runtime,os,otel,telemetry_distro", os.environ.get(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS)


### PR DESCRIPTION
## What does this pull request do?

Cite that logs exporting is disabled by default and add a reference to the environment variable. While at it reorg a bit the content of the configuration options chapter.