### PR TITLE
operator: add musl based autoinstrumentation to docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,22 @@ jobs:
     - run: pip install pip-licenses
     - run: pip-licenses
 
-  operator-requirements-installable:
+  operator-image-buildable:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/env-install
-    - run: pip install .
-    - run: pip install -r operator/requirements.txt
+    - run: pip install build
+    - run: python -m build
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+    - name: Log in to the Elastic Container registry
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      with:
+        registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
+        username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
+        password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
+    - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
 
   test:
     runs-on: ubuntu-latest

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -16,8 +16,26 @@ RUN mkdir workspace
 
 RUN pip install --no-cache-dir --target workspace /opt/distro/*.whl -r requirements.txt
 
+FROM python:3.12-alpine AS build-musl
+
+ARG DISTRO_DIR
+
+COPY ${DISTRO_DIR} /opt/distro
+
+WORKDIR /operator-build
+
+ADD operator/requirements.txt .
+
+RUN mkdir workspace
+
+RUN apk add gcc python3-dev musl-dev linux-headers
+
+RUN pip install --no-cache-dir --target workspace /opt/distro/*.whl -r requirements.txt
+
 FROM docker.elastic.co/wolfi/chainguard-base:latest@sha256:90888b190da54062f67f3fef1372eb0ae7d81ea55f5a1f56d748b13e4853d984
 
 COPY --from=build /operator-build/workspace /autoinstrumentation
+COPY --from=build-musl /operator-build/workspace /autoinstrumentation-musl
 
 RUN chmod -R go+r /autoinstrumentation
+RUN chmod -R go+r /autoinstrumentation-musl


### PR DESCRIPTION
## What does this pull request do?

Add the musl based instrumentation to the image so that it can be used by the k8s operator once supports for using it is merged.

## Related issues

Closes #138
Refs #158
