### PR TITLE
operator: install g++ on musl before installing requirements

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -28,7 +28,7 @@ ADD operator/requirements.txt .
 
 RUN mkdir workspace
 
-RUN apk add gcc python3-dev musl-dev linux-headers
+RUN apk add gcc g++ python3-dev musl-dev linux-headers
 
 RUN pip install --no-cache-dir --target workspace /opt/distro/*.whl -r requirements.txt
 


### PR DESCRIPTION
## What does this pull request do?

Install g++ on musl because the docker build started failing on arm64 with:

```
    File "/usr/local/lib/python3.12/subprocess.py", line 1955, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
  FileNotFoundError: [Errno 2] No such file or directory: 'c++'
```

## Related issues

See https://github.com/elastic/elastic-otel-python/actions/runs/11721354993/job/32648614646
