### PR TITLE
operator: bump openai instrumentation version to 0.4.0

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -53,4 +53,4 @@ opentelemetry-instrumentation-urllib==0.49b2
 opentelemetry-instrumentation-urllib3==0.49b2
 opentelemetry-instrumentation-wsgi==0.49b2
 
-elastic-opentelemetry-instrumentation-openai==0.3.0
+elastic-opentelemetry-instrumentation-openai==0.4.0


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump the version of our openai instrumentation in the docker image to the latest 0.4.0.

## Related issues