### PR TITLE
distro: set OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE to DELTA

### DIFF
--- a/src/elasticotel/distro/__init__.py
+++ b/src/elasticotel/distro/__init__.py
@@ -48,6 +48,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.environment_variables import (
     OTEL_METRICS_EXEMPLAR_FILTER,
     OTEL_EXPERIMENTAL_RESOURCE_DETECTORS,
+    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
     OTEL_EXPORTER_OTLP_PROTOCOL,
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )
@@ -141,3 +142,5 @@ class ElasticOpenTelemetryDistro(BaseDistro):
         os.environ.setdefault(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS, "process_runtime,os,otel,telemetry_distro")
         # disable exemplars by default for now
         os.environ.setdefault(OTEL_METRICS_EXEMPLAR_FILTER, "always_off")
+        # preference to use DELTA temporality as we can handle only this kind of Histograms
+        os.environ.setdefault(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "DELTA")

--- a/tests/distro/test_distro.py
+++ b/tests/distro/test_distro.py
@@ -27,6 +27,7 @@ from opentelemetry.environment_variables import (
 from opentelemetry.sdk.environment_variables import (
     OTEL_METRICS_EXEMPLAR_FILTER,
     OTEL_EXPERIMENTAL_RESOURCE_DETECTORS,
+    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
     OTEL_EXPORTER_OTLP_PROTOCOL,
 )
 
@@ -44,6 +45,7 @@ class TestDistribution(TestCase):
             "process_runtime,os,otel,telemetry_distro", os.environ.get(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS)
         )
         self.assertEqual("always_off", os.environ.get(OTEL_METRICS_EXEMPLAR_FILTER))
+        self.assertEqual("DELTA", os.environ.get(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE))
 
     @mock.patch.dict("os.environ", {}, clear=True)
     def test_load_instrumentor_call_with_default_kwargs_for_SystemMetricsInstrumentor(self):


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
We have issues accepting Histograms that does not have DELTA temporality.

## Related issues

Closes #163 
