### PR TITLE
Bump elastic-opentelemetry-instrumentation-openai dependency to 0.6.0

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -53,4 +53,4 @@ opentelemetry-instrumentation-urllib==0.49b2
 opentelemetry-instrumentation-urllib3==0.49b2
 opentelemetry-instrumentation-wsgi==0.49b2
 
-elastic-opentelemetry-instrumentation-openai==0.5.0
+elastic-opentelemetry-instrumentation-openai==0.6.0

--- a/src/elasticotel/instrumentation/bootstrap.py
+++ b/src/elasticotel/instrumentation/bootstrap.py
@@ -32,7 +32,7 @@ _EXCLUDED_INSTRUMENTATIONS = {"opentelemetry-instrumentation-openai-v2"}
 _EDOT_INSTRUMENTATIONS = [
     {
         "library": "openai >= 1.2.0",
-        "instrumentation": "elastic-opentelemetry-instrumentation-openai==0.5.0",
+        "instrumentation": "elastic-opentelemetry-instrumentation-openai==0.6.0",
     }
 ]
 


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump elastic-opentelemetry-instrumentation-openai dependency to latest available.

## Related issues

