### PR TITLE
Revise cloud detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ This distribution sets the following defaults:
 - `OTEL_METRICS_EXPORTER`: `otlp`
 - `OTEL_LOGS_EXPORTER`: `otlp`
 - `OTEL_EXPORTER_OTLP_PROTOCOL`: `grpc`
-- `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS`: `process_runtime,os,otel,telemetry_distro,_gcp,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm`
+- `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS`: `process_runtime,os,otel,telemetry_distro,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm`
 - `OTEL_METRICS_EXEMPLAR_FILTER`: `always_off`
 - `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`: `DELTA`
 
 > [!NOTE]
-> `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` cloud resource detectors are dynamically set. When running in a Kubernetes Pod it will be set to `process_runtime,os,otel,telemetry_distro,_gcp,aws_eks`.
+> `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` cloud resource detectors are dynamically set. When running in a Kubernetes Pod it will be set to `process_runtime,os,otel,telemetry_distro,aws_eks`.
 
 ### Distribution specific configuration variables
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -81,7 +81,7 @@ opentelemetry-sdk==1.29.0
     #   opentelemetry-resource-detector-azure
     #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk-extension-aws
-opentelemetry-sdk-extension-aws==2.0.2
+opentelemetry-sdk-extension-aws==2.1.0
     # via elastic-opentelemetry (pyproject.toml)
 opentelemetry-semantic-conventions==0.50b0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "opentelemetry-resourcedetector-gcp ~= 1.7.0a0",
     "opentelemetry-resource-detector-azure ~= 0.1.5",
     "opentelemetry-sdk == 1.29.0",
-    "opentelemetry-sdk-extension-aws ~= 2.0.2",
+    "opentelemetry-sdk-extension-aws ~= 2.1.0",
     "opentelemetry-semantic-conventions == 0.50b0",
     "packaging",
 ]

--- a/src/elasticotel/distro/resource_detectors.py
+++ b/src/elasticotel/distro/resource_detectors.py
@@ -18,10 +18,9 @@ import os
 
 AWS_LAMBDA_DETECTORS = ["aws_lambda"]
 AZURE_FUNCTIONS_DETECTORS = ["azure_functions"]
-GCP_CLOUD_RUN_DETECTORS = ["_gcp"]
-KUBERNETES_DETECTORS = ["_gcp", "aws_eks"]
+GCP_CLOUD_RUN_DETECTORS = []
+KUBERNETES_DETECTORS = ["aws_eks"]
 OTHER_CLOUD_DETECTORS = [
-    "_gcp",
     "aws_ec2",
     "aws_ecs",
     "aws_elastic_beanstalk",

--- a/tests/distro/test_distro.py
+++ b/tests/distro/test_distro.py
@@ -42,7 +42,7 @@ class TestDistribution(TestCase):
         self.assertEqual("otlp", os.environ.get(OTEL_LOGS_EXPORTER))
         self.assertEqual("grpc", os.environ.get(OTEL_EXPORTER_OTLP_PROTOCOL))
         self.assertEqual(
-            "process_runtime,os,otel,telemetry_distro,_gcp,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm",
+            "process_runtime,os,otel,telemetry_distro,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm",
             os.environ.get(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS),
         )
         self.assertEqual("always_off", os.environ.get(OTEL_METRICS_EXEMPLAR_FILTER))

--- a/tests/distro/test_resource_detectors.py
+++ b/tests/distro/test_resource_detectors.py
@@ -33,17 +33,17 @@ class TestGetCloudResourceDetectors(TestCase):
     @mock.patch.dict("os.environ", {"K_CONFIGURATION": "cloudrun"}, clear=True)
     def test_gcp_cloud_run(self):
         resource_detectors = get_cloud_resource_detectors()
-        self.assertEqual(resource_detectors, ["_gcp"])
+        self.assertEqual(resource_detectors, [])
 
     @mock.patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "k8s"}, clear=True)
     def test_kubernetes_pod(self):
         resource_detectors = get_cloud_resource_detectors()
-        self.assertEqual(resource_detectors, ["_gcp", "aws_eks"])
+        self.assertEqual(resource_detectors, ["aws_eks"])
 
     @mock.patch.dict("os.environ", {}, clear=True)
     def test_other_cloud_detectors(self):
         resource_detectors = get_cloud_resource_detectors()
         self.assertEqual(
             resource_detectors,
-            ["_gcp", "aws_ec2", "aws_ecs", "aws_elastic_beanstalk", "azure_app_service", "azure_vm"],
+            ["aws_ec2", "aws_ecs", "aws_elastic_beanstalk", "azure_app_service", "azure_vm"],
         )


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump the AWS ones to a version that would not print warnings when loaded outside of the expected platform and disable the GCP one because it will go into an infinite loop on GCP.

## Related issues

Refs #198 
