### PR TITLE
github-actions: exclude docker build for forked PRs or dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     - run: pip-licenses
 
   operator-image-buildable:
+    # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
+    if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## What does this pull request do?

Add a condition to skip a job for PRs from forked repositories or created by dependabot.

GitHub secrets cannot be accessed

## Related issues

Closes #ISSUE
