### PR TITLE
ci: use elastic registry only if available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     - run: pip-licenses
 
   operator-image-buildable:
+    env:
+      USE_ELASTIC_REGISTRY: ${{ github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' ) }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -54,11 +56,11 @@ jobs:
         registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
         username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
         password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
-      if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
+      if: ${{ env.USE_ELASTIC_REGISTRY }}
     - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
-      if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
+      if: ${{ env.USE_ELASTIC_REGISTRY }}
     - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/busybox --build-arg IMAGE_VERSION=latest .
-      if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]')
+      if: ${{ ! env.USE_ELASTIC_REGISTRY }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,7 @@ jobs:
     - run: python -m build
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-    - name: Log in to the Elastic Container registry
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-      with:
-        registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
-        username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
-        password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
-    - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
+    - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/busybox --build-arg IMAGE_VERSION=latest .
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,17 @@ jobs:
     - run: python -m build
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+    - name: Log in to the Elastic Container registry
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      with:
+        registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
+        username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
+        password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
+      if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
+    - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
+      if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
     - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/busybox --build-arg IMAGE_VERSION=latest .
+      if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]')
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
         username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
         password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
-      if: ${{ env.USE_ELASTIC_REGISTRY }}
+      if: ${{ env.USE_ELASTIC_REGISTRY == 'true' }}
     - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
       if: ${{ env.USE_ELASTIC_REGISTRY }}
     - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest-dev --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/bash --build-arg IMAGE_VERSION=latest .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       if: ${{ env.USE_ELASTIC_REGISTRY }}
     - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
       if: ${{ env.USE_ELASTIC_REGISTRY }}
-    - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest-dev --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/busybox --build-arg IMAGE_VERSION=latest .
+    - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest-dev --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/bash --build-arg IMAGE_VERSION=latest .
       if: ${{ ! env.USE_ELASTIC_REGISTRY }}
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
       if: ${{ env.USE_ELASTIC_REGISTRY == 'true' }}
     - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest-dev --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/bash --build-arg IMAGE_VERSION=latest .
-      if: ${{ ! env.USE_ELASTIC_REGISTRY }}
+      if: ${{ env.USE_ELASTIC_REGISTRY != 'true'}}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
       if: ${{ env.USE_ELASTIC_REGISTRY == 'true' }}
     - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
-      if: ${{ env.USE_ELASTIC_REGISTRY }}
+      if: ${{ env.USE_ELASTIC_REGISTRY == 'true' }}
     - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest-dev --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/bash --build-arg IMAGE_VERSION=latest .
       if: ${{ ! env.USE_ELASTIC_REGISTRY }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       if: ${{ env.USE_ELASTIC_REGISTRY }}
     - run: docker build -f operator/Dockerfile --build-arg DISTRO_DIR=./dist .
       if: ${{ env.USE_ELASTIC_REGISTRY }}
-    - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/busybox --build-arg IMAGE_VERSION=latest .
+    - run: docker build -f operator/Dockerfile --build-arg PYTHON_GLIBC_IMAGE=cgr.dev/chainguard/python --build-arg PYTHON_GLIBC_IMAGE_VERSION=latest-dev --build-arg DISTRO_DIR=./dist --build-arg IMAGE=cgr.dev/chainguard/busybox --build-arg IMAGE_VERSION=latest .
       if: ${{ ! env.USE_ELASTIC_REGISTRY }}
 
   test:

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,4 +1,10 @@
-FROM docker.elastic.co/wolfi/python:3.12-dev@sha256:2f10787cc037b197f6a5d1a031c31706ae59642708c8b3b5ddfd3fa79605e9ad AS build
+ARG PYTHON_GLIBC_IMAGE="docker.elastic.co/wolfi/python"
+ARG PYTHON_GLIBC_IMAGE_VERSION="3.12-dev@sha256:2f10787cc037b197f6a5d1a031c31706ae59642708c8b3b5ddfd3fa79605e9ad"
+
+ARG IMAGE="docker.elastic.co/wolfi/chainguard-base"
+ARG IMAGE_VERSION="latest@sha256:26caa6beaee2bbf739a82e91a35173892dfe888d0a744b9e46cdc19a90d8656f"
+
+FROM ${PYTHON_GLIBC_IMAGE}:${PYTHON_GLIBC_IMAGE_VERSION} AS build
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -32,7 +38,7 @@ RUN apk add gcc g++ python3-dev musl-dev linux-headers
 
 RUN pip install --no-cache-dir --target workspace /opt/distro/*.whl -r requirements.txt
 
-FROM docker.elastic.co/wolfi/chainguard-base:latest@sha256:26caa6beaee2bbf739a82e91a35173892dfe888d0a744b9e46cdc19a90d8656f
+FROM ${IMAGE}:${IMAGE_VERSION}
 
 COPY --from=build /operator-build/workspace /autoinstrumentation
 COPY --from=build-musl /operator-build/workspace /autoinstrumentation-musl


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

The elastic docker registry is not available for forks of this repo or to dependabot so if you cannot use it use alternative upstream docker images.