### PR TITLE
resources: introduce a resource detector sending server.instance.id

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -48,12 +48,12 @@ EDOT Python uses different defaults than OpenTelemetry Python for the following 
 
 | Option | EDOT Python default | OpenTelemetry Python default |
 |---|---|---|
-| `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | `process_runtime,os,otel,telemetry_distro,_gcp,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm` | `otel` |
+| `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | `process_runtime,os,otel,telemetry_distro,service_instance,_gcp,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm` | `otel` |
 | `OTEL_METRICS_EXEMPLAR_FILTER` | `always_off` | `trace_based` |
 | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | `DELTA` | `CUMULATIVE` |
 
 > [!NOTE]
-> `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` cloud resource detectors are dynamically set. When running in a Kubernetes Pod it will be set to `process_runtime,os,otel,telemetry_distro,_gcp,aws_eks`.
+> `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` cloud resource detectors are dynamically set. When running in a Kubernetes Pod it will be set to `process_runtime,os,otel,telemetry_distro,service_instance,_gcp,aws_eks`.
 
 
 ### Configuration options that are _only_ available in EDOT Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ distro = "elasticotel.distro:ElasticOpenTelemetryDistro"
 [project.entry-points.opentelemetry_resource_detector]
 process_runtime = "elasticotel.sdk.resources:ProcessRuntimeResourceDetector"
 telemetry_distro = "elasticotel.sdk.resources:TelemetryDistroResourceDetector"
+service_instance = "elasticotel.sdk.resources:ServiceInstanceResourceDetector"
 _gcp = "opentelemetry.resourcedetector.gcp_resource_detector._detector:GoogleCloudResourceDetector"
 
 [project.scripts]

--- a/src/elasticotel/distro/__init__.py
+++ b/src/elasticotel/distro/__init__.py
@@ -75,6 +75,6 @@ class ElasticOpenTelemetryDistro(BaseDistro):
         # preference to use DELTA temporality as we can handle only this kind of Histograms
         os.environ.setdefault(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "DELTA")
 
-        base_resource_detectors = ["process_runtime", "os", "otel", "telemetry_distro"]
+        base_resource_detectors = ["process_runtime", "os", "otel", "telemetry_distro", "service_instance"]
         detectors = base_resource_detectors + get_cloud_resource_detectors()
         os.environ.setdefault(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS, ",".join(detectors))

--- a/src/elasticotel/sdk/resources/__init__.py
+++ b/src/elasticotel/sdk/resources/__init__.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 import sys
+import uuid
 
 from opentelemetry.semconv._incubating.attributes import telemetry_attributes
+from opentelemetry.semconv._incubating.attributes import service_attributes
 from opentelemetry.sdk.resources import (
     Attributes,
     Resource,
@@ -48,6 +50,16 @@ class ProcessRuntimeResourceDetector(ResourceDetector):
             PROCESS_RUNTIME_NAME: sys.implementation.name,
             PROCESS_RUNTIME_VERSION: runtime_version,
         }
+        return Resource(resource_info)
+
+
+class ServiceInstanceResourceDetector(ResourceDetector):
+    """Resource detector to fill service instance attributes
+
+    NOTE: with multi-process services this is shared between processes"""
+
+    def detect(self) -> "Resource":
+        resource_info: Attributes = {service_attributes.SERVICE_INSTANCE_ID: str(uuid.uuid4())}
         return Resource(resource_info)
 
 

--- a/tests/distro/test_distro.py
+++ b/tests/distro/test_distro.py
@@ -42,7 +42,7 @@ class TestDistribution(TestCase):
         self.assertEqual("otlp", os.environ.get(OTEL_LOGS_EXPORTER))
         self.assertEqual("grpc", os.environ.get(OTEL_EXPORTER_OTLP_PROTOCOL))
         self.assertEqual(
-            "process_runtime,os,otel,telemetry_distro,_gcp,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm",
+            "process_runtime,os,otel,telemetry_distro,service_instance,_gcp,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm",
             os.environ.get(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS),
         )
         self.assertEqual("always_off", os.environ.get(OTEL_METRICS_EXEMPLAR_FILTER))

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -14,9 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
-from elasticotel.sdk.resources import ProcessRuntimeResourceDetector, TelemetryDistroResourceDetector
+from elasticotel.sdk.resources import (
+    ProcessRuntimeResourceDetector,
+    ServiceInstanceResourceDetector,
+    TelemetryDistroResourceDetector,
+)
 from opentelemetry.sdk.resources import (
     PROCESS_RUNTIME_NAME,
     PROCESS_RUNTIME_DESCRIPTION,
@@ -37,6 +41,20 @@ class TestProcessRuntimeDetector(TestCase):
             sorted(aggregated_resource.attributes.keys()),
             [PROCESS_RUNTIME_DESCRIPTION, PROCESS_RUNTIME_NAME, PROCESS_RUNTIME_VERSION],
         )
+
+
+class TestServiceInstanceDetector(TestCase):
+    def test_service_instance_detector(self):
+        initial_resource = Resource(attributes={})
+        aggregated_resource = get_aggregated_resources([ServiceInstanceResourceDetector()], initial_resource)
+
+        self.assertEqual(
+            aggregated_resource.attributes,
+            {
+                "service.instance.id": mock.ANY,
+            },
+        )
+        self.assertTrue(isinstance(aggregated_resource.attributes["service.instance.id"], str))
 
 
 class TestTelemetryDistroDetector(TestCase):


### PR DESCRIPTION
## What does this pull request do?

Introduce a resource detector sending a stringified UUIDv4 as value for `service.instance.id` attribute.
And enable it by default.

## Related issues

Closes #258
