### PR TITLE
Relax openai instrumentation dependency in boostrap

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -55,4 +55,4 @@ opentelemetry-instrumentation-urllib==0.51b0
 opentelemetry-instrumentation-urllib3==0.51b0
 opentelemetry-instrumentation-wsgi==0.51b0
 
-elastic-opentelemetry-instrumentation-openai==0.6.0
+elastic-opentelemetry-instrumentation-openai==0.6.1

--- a/src/elasticotel/instrumentation/bootstrap.py
+++ b/src/elasticotel/instrumentation/bootstrap.py
@@ -32,7 +32,7 @@ _EXCLUDED_INSTRUMENTATIONS = {"opentelemetry-instrumentation-openai-v2", "opente
 _EDOT_INSTRUMENTATIONS = [
     {
         "library": "openai >= 1.2.0",
-        "instrumentation": "elastic-opentelemetry-instrumentation-openai==0.6.0",
+        "instrumentation": "elastic-opentelemetry-instrumentation-openai",
     }
 ]
 


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
So we can release the elastic openai instrumentation without requiring a release of EDOT.
While at it bump the elastic openai instrumentation version installed in the Dockerfile to latest.

## Related issues

