### PR TITLE
operator: bump openai instrumentation to 1.0.0 in docker image

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -55,4 +55,4 @@ opentelemetry-instrumentation-urllib==0.52b1
 opentelemetry-instrumentation-urllib3==0.52b1
 opentelemetry-instrumentation-wsgi==0.52b1
 
-elastic-opentelemetry-instrumentation-openai==0.7.0
+elastic-opentelemetry-instrumentation-openai==1.0.0


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump to latest release elastic-opentelemetry-instrumentation-openai in the operator image.

## Related issues
