### PR TITLE
dependabot: use directories and use docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 ---
 version: 2
+registries:
+  docker-elastic:
+    type: docker-registry
+    url: https://docker.elastic.co
+    username: ${{secrets.ELASTIC_DOCKER_USERNAME}}
+    password: ${{secrets.ELASTIC_DOCKER_PASSWORD}}
+
 updates:
   # Enable version updates for python
   - package-ecosystem: "pip"
@@ -12,9 +19,10 @@ updates:
     reviewers:
       - "elastic/apm-agent-python"
 
-  # GitHub actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - '/'
+      - '/.github/actions/*'
     reviewers:
       - "elastic/observablt-ci"
     schedule:
@@ -26,16 +34,11 @@ updates:
         patterns:
           - "*"
 
-  # GitHub composite actions
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/env-install"
+  - package-ecosystem: "docker"
+    directories:
+      - '/'
     reviewers:
-      - "elastic/observablt-ci"
+      - "elastic/apm-agent-python"
+    registries: "*"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "22:00"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+      interval: "daily"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "github>elastic/renovate-config:only-chainguard"
-    ]
-}


### PR DESCRIPTION
## What does this pull request do?

Use `dependabot` for updating docker images stored in our internal docker registry using [this](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot).

Use `directories` to manage the dependencies for the GitHub workflow sand composite actions.

### Why

We already have secrets stored for accessing the internal docker registry. Use one dependency management tool with native support for GitHub actions and the [GH secrets access control](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/). 

This has been already tested in the past in a sandbox repository and also in another GH internal repositories.

### Actions

- [x] Create Dependabot GitHub secret using CasC.

## Related issues

See https://github.com/elastic/apm-agent-python/pull/2246
