### PR TITLE
renovate: limit update to python wolfi images only to patch releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,13 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>elastic/renovate-config:only-chainguard"
+    ],
+    "separateMinorPatch": true,
+    "packageRules": [
+        {
+            "groupName": "python",
+            "matchUpdateTypes": ["patch"],
+            "matchPackageNames": ["wolfi/python"]
+        }
     ]
 }


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Limit update to wolfi/python images to only patch releases because we want to stay on the same major.minor python version.

## Related issues

Refs #274
