### PR TITLE
operator: bump openai instrumentation to 1.1.1

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -56,4 +56,4 @@ opentelemetry-instrumentation-urllib==0.54b1
 opentelemetry-instrumentation-urllib3==0.54b1
 opentelemetry-instrumentation-wsgi==0.54b1
 
-elastic-opentelemetry-instrumentation-openai==1.1.0
+elastic-opentelemetry-instrumentation-openai==1.1.1


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bumps installed elastic-opentelemetry-instrumentation-openai in operator docker image to latest

## Related issues

Closes #ISSUE
