### PR TITLE
ci: move from dependabot reviews to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+*  @elastic/apm-agent-python
+/.github/actions/  @elastic/apm-agent-python @elastic/observablt-ci
+/.github/workflows/  @elastic/apm-agent-python @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,15 +16,11 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "elastic/apm-agent-python"
 
   - package-ecosystem: "github-actions"
     directories:
       - '/'
       - '/.github/actions/*'
-    reviewers:
-      - "elastic/observablt-ci"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -38,8 +34,6 @@ updates:
     directories:
       - '/'
       - 'operator/*'
-    reviewers:
-      - "elastic/apm-agent-python"
     registries: "*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
After https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Hat tip to @trentm