### PR TITLE
distro: set OTEL_TRACES_SAMPLER_ARG to 1.0 by default

### DIFF
--- a/src/elasticotel/distro/__init__.py
+++ b/src/elasticotel/distro/__init__.py
@@ -36,6 +36,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
     OTEL_EXPORTER_OTLP_PROTOCOL,
     OTEL_TRACES_SAMPLER,
+    OTEL_TRACES_SAMPLER_ARG,
 )
 from opentelemetry.sdk.resources import OTELResourceDetector
 from opentelemetry.util._importlib_metadata import EntryPoint
@@ -116,6 +117,7 @@ class ElasticOpenTelemetryDistro(BaseDistro):
         # preference to use DELTA temporality as we can handle only this kind of Histograms
         os.environ.setdefault(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "DELTA")
         os.environ.setdefault(OTEL_TRACES_SAMPLER, "parentbased_traceidratio")
+        os.environ.setdefault(OTEL_TRACES_SAMPLER_ARG, "1.0")
 
         base_resource_detectors = ["process_runtime", "os", "otel", "telemetry_distro", "service_instance"]
         detectors = base_resource_detectors + get_cloud_resource_detectors()

--- a/tests/distro/test_distro.py
+++ b/tests/distro/test_distro.py
@@ -33,6 +33,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
     OTEL_EXPORTER_OTLP_PROTOCOL,
     OTEL_TRACES_SAMPLER,
+    OTEL_TRACES_SAMPLER_ARG,
 )
 from opentelemetry.sdk.trace import sampling
 from opentelemetry._opamp.proto import opamp_pb2 as opamp_pb2
@@ -54,6 +55,7 @@ class TestDistribution(TestCase):
         self.assertEqual("always_off", os.environ.get(OTEL_METRICS_EXEMPLAR_FILTER))
         self.assertEqual("DELTA", os.environ.get(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE))
         self.assertEqual("parentbased_traceidratio", os.environ.get(OTEL_TRACES_SAMPLER))
+        self.assertEqual("1.0", os.environ.get(OTEL_TRACES_SAMPLER_ARG))
 
     @mock.patch.dict("os.environ", {}, clear=True)
     def test_sampler_configuration(self):


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Otherwise the SDK will warn about empty string not being a float.

## Related issues
