### PR TITLE
distro: override otlp exporters user agent headers

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -18,6 +18,7 @@ import os.path
 
 import pytest
 
+from elasticotel.distro import version
 from .utils import ElasticIntegrationTestCase, OTEL_INSTRUMENTATION_VERSION, ROOT_DIR
 
 
@@ -128,8 +129,7 @@ class IntegrationTestCase(ElasticIntegrationTestCase):
 
     def test_log_events_are_sent(self):
         def send_event():
-            from opentelemetry._events import Event
-            from opentelemetry._events import get_event_logger
+            from opentelemetry._events import Event, get_event_logger
 
             event = Event(name="test.event", attributes={}, body={"key": "value", "dict": {"nestedkey": "nestedvalue"}})
             event_logger = get_event_logger(__name__)
@@ -141,6 +141,38 @@ class IntegrationTestCase(ElasticIntegrationTestCase):
         (log,) = telemetry["logs"]
         self.assertEqual(log["attributes"]["event.name"], "test.event")
         self.assertEqual(log["body"], {"key": "value", "dict": {"nestedkey": "nestedvalue"}})
+
+    def test_edot_user_agent_is_used_in_otlp_grpc_exporter(self):
+        def test_script():
+            import sqlite3
+
+            from opentelemetry._events import Event, get_event_logger
+
+            connection = sqlite3.connect(":memory:")
+            cursor = connection.cursor()
+            cursor.execute("CREATE TABLE movie(title, year, score)")
+
+            event = Event(name="test.event", attributes={}, body={"key": "value"})
+            event_logger = get_event_logger(__name__)
+            event_logger.emit(event)
+
+        stdout, stderr, returncode = self.run_script(test_script, wrapper_script="opentelemetry-instrument")
+
+        telemetry = self.get_telemetry()
+        (metrics_headers, logs_headers, traces_headers) = (
+            telemetry["metrics_headers"],
+            telemetry["logs_headers"],
+            telemetry["traces_headers"],
+        )
+
+        assert metrics_headers
+        assert traces_headers
+        assert logs_headers
+
+        edot_user_agent = "elastic-otlp-grpc-python/" + version.__version__
+        self.assertIn(edot_user_agent, metrics_headers[0]["user-agent"])
+        self.assertIn(edot_user_agent, traces_headers[0]["user-agent"])
+        self.assertIn(edot_user_agent, logs_headers[0]["user-agent"])
 
 
 @pytest.mark.integration

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -156,6 +156,7 @@ class ElasticIntegrationTestCase(unittest.TestCase):
             return dict_values
 
         metrics = []
+        metrics_headers = []
         for request in telemetry["metric_requests"]:
             elems = []
             for proto_elem in request["pbreq"]["resourceMetrics"]:
@@ -176,7 +177,10 @@ class ElasticIntegrationTestCase(unittest.TestCase):
             metric = {"resourceMetrics": elems}
             metrics.append(metric)
 
+            metrics_headers.append(request["headers"])
+
         traces = []
+        traces_headers = []
         for request in telemetry["trace_requests"]:
             for resource_span in request["pbreq"]["resourceSpans"]:
                 resource_attributes = normalize_attributes(resource_span["resource"]["attributes"])
@@ -188,8 +192,10 @@ class ElasticIntegrationTestCase(unittest.TestCase):
                         span["spanId"] = decode_id(span["spanId"])
                         span["traceId"] = decode_id(span["traceId"])
                         traces.append(span)
+            traces_headers.append(request["headers"])
 
         logs = []
+        logs_headers = []
         for request in telemetry["log_requests"]:
             for resource_log in request["pbreq"]["resourceLogs"]:
                 resource_attributes = normalize_attributes(resource_log["resource"]["attributes"])
@@ -200,11 +206,15 @@ class ElasticIntegrationTestCase(unittest.TestCase):
                         log["body"] = normalize_kvlist(log["body"])
                         log["resource"] = resource_attributes
                         logs.append(log)
+            logs_headers.append(request["headers"])
 
         return {
             "logs": logs,
+            "logs_headers": logs_headers,
             "metrics": metrics,
+            "metrics_headers": metrics_headers,
             "traces": traces,
+            "traces_headers": traces_headers,
         }
 
     def run_script(


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

For GRPC we leverage the recently added channel_options, for HTTP we temporarily need to monkey patch the exporter default headers in the meantime we have an sdk where we can override them.

This is in draft because I need to extend the integration test machinery in order to also test the http exporter.

## Related issues

Closes #ISSUE
