### PR TITLE
Add reference docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ tests/*-junit.xml
 .aws
 .arn-file.md
 __pycache__
+.artifacts
+docs/.artifacts

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -2,9 +2,23 @@ project: 'EDOT Python release notes'
 cross_links:
   - docs-content
   - opentelemetry
+  - elastic-agent
+  - apm-agent-python
 toc:
   - toc: release-notes
+  - toc: reference
 subs:
+  motlp: Elastic Cloud Managed OTLP Endpoint
+  edot: Elastic Distribution of OpenTelemetry
+  ecloud:   "Elastic Cloud"
+  edot-cf:   "EDOT Cloud Forwarder"
+  ech:   "Elastic Cloud Hosted"
+  ess:   "Elasticsearch Service"
+  ece:   "Elastic Cloud Enterprise"
+  serverless-full:   "Elastic Cloud Serverless"
   agent:   "Elastic Agent"
   agents:   "Elastic Agents"
-  edot:    "Elastic Distribution of OpenTelemetry"
+  stack:   "Elastic Stack"
+  es:   "Elasticsearch"
+  kib:   "Kibana"
+  ls:   "Logstash"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,124 @@
+---
+navigation_title: Configuration
+description: Configure the Elastic Distribution of OpenTelemetry Python (EDOT Python) to send data to Elastic.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Configure the EDOT Python agent
+
+Configure the {{edot}} Python (EDOT Python) to send data to Elastic.
+
+## Configuration method
+
+Configure the OpenTelemetry SDK through the mechanisms [documented on the OpenTelemetry website](https://opentelemetry.io/docs/zero-code/python/configuration/). EDOT Python is typically configured with `OTEL_*` environment variables defined by the OpenTelemetry spec. For example:
+
+```sh
+export OTEL_RESOURCE_ATTRIBUTES=service.name=<app-name>,deployment.environment.name=<env-name>
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://my-deployment.ingest.us-west1.gcp.cloud.es.io
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey P....l"
+opentelemetry-instrument <command to start your service>
+```
+
+## Configuration options
+
+Because the {{edot}} Python is an extension of OpenTelemetry Python, it supports both:
+
+* [General OpenTelemetry configuration options](#opentelemetry-configuration-options)
+* [Specific configuration options that are only available in EDOT Python](#configuration-options-only-available-in-edot-python)
+
+## Central configuration
+
+```{applies_to}
+serverless: unavailable
+stack: preview 9.1 
+product:
+  edot_python: preview 1.4.0
+```
+
+APM Agent Central Configuration lets you configure EDOT Python instances remotely, see [Central configuration docs](opentelemetry://reference/central-configuration.md) for more details.
+
+### Turn on central configuration
+
+To activate central configuration, set the `ELASTIC_OTEL_OPAMP_ENDPOINT` environment variable to the OpAMP server endpoint.
+
+```sh
+export ELASTIC_OTEL_OPAMP_ENDPOINT=http://localhost:4320/v1/opamp
+```
+
+To deactivate central configuration, remove the `ELASTIC_OTEL_OPAMP_ENDPOINT` environment variable and restart the instrumented application.
+
+### Central configuration settings
+
+You can modify the following settings for EDOT Python through APM Agent Central Configuration:
+
+| Settings      | Description                                  | Type    | Versions |
+|---------------|----------------------------------------------|---------|---------|
+| Logging level | Configure EDOT Python agent logging level.   | Dynamic | {applies_to}`stack: preview 9.1` <br> {applies_to}`edot_python: preview 1.4.0` |
+| Sampling rate | Configure EDOT Python tracing sampling rate. | Dynamic | {applies_to}`stack: preview 9.2` <br> {applies_to}`edot_python: preview 1.7.0` |
+
+Dynamic settings can be changed without having to restart the application.
+
+### OpenTelemetry configuration options
+
+EDOT Python supports all configuration options listed in the [OpenTelemetry General SDK Configuration documentation](https://opentelemetry.io/docs/languages/sdk-configuration/general/) and [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python).
+
+#### Logs
+
+Instrument Python `logging` module to format and forward logs in OTLP format is turned off by default and gated under a configuration environment variable:
+
+```sh
+export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+```
+
+:::{note}
+Turning this on will make any call to [logging.basicConfig](https://docs.python.org/3/library/logging.html#logging.basicConfig) from your application a no-op.
+:::
+
+#### Differences from OpenTelemetry Python
+
+EDOT Python uses different defaults than OpenTelemetry Python for the following configuration options:
+
+| Option | EDOT Python default | OpenTelemetry Python default |
+|---|---|---|
+| `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | `process_runtime,os,otel,telemetry_distro,service_instance,containerid,_gcp,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm` | `otel` |
+| `OTEL_METRICS_EXEMPLAR_FILTER` | `always_off` | `trace_based` |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | `DELTA` | `CUMULATIVE` |
+| `OTEL_TRACES_SAMPLER` | `parentbased_traceidratio` | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | `1.0` | |
+
+:::{note}
+`OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` cloud resource detectors are dynamically set. When running in a Kubernetes Pod it will be set to `process_runtime,os,otel,telemetry_distro,service_instance,_gcp,aws_eks`.
+:::
+
+
+### Configuration options only available in EDOT Python
+
+`ELASTIC_OTEL_` options are specific to Elastic and will always live in EDOT Python include the following.
+
+| Option(s) | Default | Description |
+|---|---|---|
+| `ELASTIC_OTEL_SYSTEM_METRICS_ENABLED` | `false` | When sets to `true`, sends *system namespace* metrics. |
+
+## LLM settings
+
+LLM instrumentations implement the following configuration options:
+
+| Option                                                | default | description               |
+|-------------------------------------------------------|---------|:--------------------------|
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`  | `false`| If set to `true`, enables the capturing of request and response content in the log events outputted by the agent.
+
+
+## Prevent logs export
+
+To prevent logs from being exported, set `OTEL_LOGS_EXPORTER` to `none`. However, application logs might still be gathered and exported by the Collector through the `filelog` receiver.
+
+To prevent application logs from being collected and exported by the Collector, refer to [Exclude paths from logs collection](elastic-agent://reference/edot-collector/config/configure-logs-collection.md#exclude-logs-paths).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,38 @@
+---
+navigation_title: EDOT Python
+description: The Elastic Distribution of OpenTelemetry Python (EDOT Python) is a customized version of OpenTelemetry Python.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Elastic Distribution of OpenTelemetry Python
+
+The [{{edot}} (EDOT) Python](https://github.com/elastic/elastic-otel-python) is a customized version of [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python), configured for the best experience with Elastic Observability. 
+
+Use EDOT Python to start the OpenTelemetry SDK with your Python application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
+
+A goal of this distribution is to avoid introducing proprietary concepts in addition to those defined by the wider OpenTelemetry community. For any additional features introduced, Elastic aims at contributing them back to the OpenTelemetry project.
+
+## Features
+
+In addition to all the features of the OpenTelemetry Python agent, with EDOT Python you have access to the following:
+
+* Improvements and bug fixes contributed by the Elastic team before the changes are available in OpenTelemetry repositories.
+* Optional features that can enhance OpenTelemetry data that is being sent to Elastic.
+* Elastic-specific processors that ensure optimal compatibility when exporting OpenTelemetry signal data to an Elastic backend like an Elastic Observability deployment.
+* Preconfigured collection of tracing and metrics signals, applying some opinionated defaults, such as which sources are collected by default.
+* Compatibility with APM Agent Central Configuration to modify the settings of the EDOT Python agent without having to restart the application.
+
+Follow the step-by-step instructions in [Setup](/reference/setup/index.md) to get started.
+
+## Release notes
+
+For the latest release notes, including known issues, deprecations, and breaking changes, refer to [EDOT Python release notes](/release-notes/index.md)

--- a/docs/reference/migration.md
+++ b/docs/reference/migration.md
@@ -1,0 +1,135 @@
+---
+navigation_title: Migration
+description: Migrate from the Elastic APM Python agent to the Elastic Distribution of OpenTelemetry Python (EDOT Python).
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+  - id: apm-agent
+---
+
+# Migrate to EDOT Python from the Elastic APM Python agent
+
+Learn the differences between the [Elastic APM Python agent](apm-agent-python://reference/index.md) and the {{edot}} Python (EDOT Python).
+
+Follow the steps to migrate your instrumentation and settings. For step-by-step instructions on setting up EDOT Python refer to [Setup](/reference/setup/index.md).
+
+## Migration steps
+
+Follow these steps to migrate:
+
+1. Remove any configuration and setup code needed by Elastic APM Python Agent from your application source code.
+2. Migrate any usage of Elastic APM Python Agent API to manual instrumentation with OpenTelemetry API in the application source code.
+3. Follow the [setup documentation](setup/index.md) on to install and configure EDOT Python.
+
+## Configuration mapping
+
+The following are Elastic APM Python agent settings that you can migrate to EDOT Python.
+
+### `api_key`
+
+The Elastic [`api_key`](apm-agent-python://reference/configuration.md#config-api-key) option corresponds to the OpenTelemetry [OTEL_EXPORTER_OTLP_HEADERS](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_headers) option.
+
+For example: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey an_api_key"`.
+
+### `enabled`
+
+The Elastic [`enabled`](apm-agent-python://reference/configuration.md#config-enabled) option corresponds to the OpenTelemetry [OTEL_SDK_DISABLED](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) option.
+
+### `environment`
+
+The Elastic [`environment`](apm-agent-python://reference/configuration.md#config-environment) option corresponds to setting the `deployment.environment.name` key in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+
+For example: `OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=testing`.
+
+### `global_labels`
+
+The Elastic [`global_labels`](apm-agent-python://reference/configuration.md#config-global_labels) option corresponds to adding `key=value` comma separated pairs in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+
+For example: `OTEL_RESOURCE_ATTRIBUTES=alice=first,bob=second`. Such labels will result in labels.key=value attributes on the server, e.g. labels.alice=first
+
+### `metrics_interval`
+
+The Elastic [`metrics_interval`](apm-agent-python://reference/configuration.md#config-metrics_interval) corresponds to the OpenTelemetry [OTEL_METRIC_EXPORT_INTERVAL](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader) option.
+
+For example: `OTEL_METRIC_EXPORT_INTERVAL=30000`.
+
+### `secret_token`
+
+The Elastic [`secret_token`](apm-agent-python://reference/configuration.md#config-secret-token) option corresponds to the OpenTelemetry [OTEL_EXPORTER_OTLP_HEADERS](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_headers) option.
+
+For example: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey an_apm_secret_token"`.
+
+### `server_url`
+
+The Elastic [`server_url`](apm-agent-python://reference/configuration.md#config-server-url) option corresponds to the OpenTelemetry [`OTEL_EXPORTER_OTLP_ENDPOINT`](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_endpoint) option.
+
+### `service_name`
+
+The Elastic [`service_name`](apm-agent-python://reference/configuration.md#config-service-name) option corresponds to the OpenTelemetry [OTEL_SERVICE_NAME](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_service_name) option.
+
+You can also set the service name using [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+
+For example: `OTEL_RESOURCE_ATTRIBUTES=service.name=myservice`. If `OTEL_SERVICE_NAME` is set, it takes precedence over the resource attribute.
+
+### `service_version`
+
+The Elastic [`service_version`](apm-agent-python://reference/configuration.md#config-service-version) option corresponds to setting the `service.version` key in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+
+For example: `OTEL_RESOURCE_ATTRIBUTES=service.version=1.2.3`.
+
+## Performance overhead
+
+Evaluate the [differences in performance overhead](/reference/overhead.md) between EDOT Python and Elastic APM Python agent.
+
+## Limitations
+
+The following limitations apply when migrating to EDOT Python.
+
+### Central and dynamic configuration
+
+You can manage EDOT Python configurations through the [central configuration feature](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) in the Applications UI.
+
+Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more information.
+
+### AWS Lambda
+
+A custom lambda layer for the {{edot}} Python is not currently available. Refer to the [Lambda Auto-Instrumentation](https://opentelemetry.io/docs/faas/lambda-auto-instrument/).
+
+### Missing instrumentations
+
+The following libraries are currently missing an OpenTelemetry equivalent:
+
+- Azure storage and Azure queue
+- `aiobotocore`
+- `aiomysql`
+- `aioredis`
+- `Graphene`
+- `httplib2`
+- `pylibmc`
+- `pyodbc`
+- `python-memcached`
+- `Sanic`
+- `zlib`
+
+### Integration with structured logging
+
+EDOT Python lacks a [structlog integration](apm-agent-python://reference/logs.md#structlog) at the moment.
+
+### Span compression
+
+EDOT Python does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
+
+### Breakdown metrics
+
+EDOT Python is not sending metrics that power the [Breakdown metrics](docs-content://solutions/observability/apm/metrics.md#_breakdown_metrics).
+
+## Troubleshooting
+
+If you're encountering issues during migration, refer to the [EDOT Python troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/python/index.md).

--- a/docs/reference/overhead.md
+++ b/docs/reference/overhead.md
@@ -1,0 +1,33 @@
+---
+navigation_title: Performance overhead
+description: This page explains the performance considerations when instrumenting Python applications with the Elastic Distribution of OpenTelemetry SDK, including impact analysis and mitigation techniques.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Performance overhead of the EDOT SDK for Python
+
+This page explains the performance considerations when instrumenting Python applications with the Elastic Distribution of OpenTelemetry SDK, including impact analysis and mitigation techniques.
+
+While designed to have minimal performance overhead, the EDOT Java agent, like any instrumentation agent, executes within the application process and thus has a small influence on the application performance. 
+
+This performance overhead depends on the application's technical architecture, its configuration and environment, and the load. These factors are not easy to reproduce on their own, and all applications are different, so it is not possible to provide a simple answer.
+
+## Benchmark 
+
+The following numbers are only provided as indicators, and you should not attempt to extrapolate them. Use them as a framework to evaluate and measure the overhead on your applications.
+
+The following table compares the response times of a sample web application without an agent, with Elastic APM Python Agent and with EDOT Python Agent in two situations: without data loaded and serialized to measure the minimal overhead of agents and with some data loaded and then serialized to provide a more common scenario.
+
+|                                   | No agent  | EDOT Python agent | Elastic APM Python agent |
+|-----------------------------------|-----------|-----------------------------|--------------------------|
+| No data: Time taken for tests     | 1.277 s   | 2.215 s                     | 2.313 s                  |
+| Sample data: Time taken for tests | 4.546 s   | 6.401 s                     | 6.159 s                  |

--- a/docs/reference/setup/index.md
+++ b/docs/reference/setup/index.md
@@ -1,0 +1,85 @@
+---
+navigation_title: Setup
+description: Learn how to set up and configure the Elastic Distribution of OpenTelemetry (EDOT) Python to instrument your application or service.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Set up the EDOT Python agent
+
+Learn how to set up the {{edot}} (EDOT) Python in various environments, including Kubernetes and others.
+
+Follow these steps to get started.
+
+:::{warning}
+Avoid using the Python SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+:::
+
+::::::{stepper}
+
+::::{step} Install the distribution
+Install EDOT Python by running pip:
+
+```bash
+pip install elastic-opentelemetry
+```
+::::
+
+::::{step} Install the available instrumentation
+EDOT Python doesn't install any instrumentation package by default. Instead, it relies on the `edot-bootstrap` command to scan the installed packages and install the available instrumentation. The following command installs all the instrumentations available for libraries installed in your environment:
+
+```bash
+edot-bootstrap --action=install
+```
+
+:::{note}
+Add this command every time you deploy an updated version of your application. Also add it to your container image build process.
+:::
+::::
+
+::::{step} Configure EDOT Python
+Refer to [Observability quickstart](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) documentation on how to setup your environment.
+
+To configure EDOT Python you need to set a few `OTLP_*` environment variables that are available when running EDOT Python:
+
+* `OTEL_RESOURCE_ATTRIBUTES`: Use this to add a `service.name` and `deployment.environment`. This makes it easier to recognize your application when reviewing data sent to Elastic.
+
+The following environment variables are not required if you are sending data through a local EDOT Collector but are provided in the Elastic Observability platform onboarding:
+
+* `OTEL_EXPORTER_OTLP_ENDPOINT`: The full URL of the endpoint where data will be sent.
+* `OTEL_EXPORTER_OTLP_HEADERS`: A comma-separated list of `key=value` pairs that will be added to the headers of every request. This is typically used for authentication information.
+::::
+
+::::{step} Run EDOT Python
+Wrap your service invocation with `opentelemetry-instrument`, which is the wrapper that provides automatic instrumentation. For example, a web service running with gunicorn might look like this:
+
+```bash
+opentelemetry-instrument gunicorn main:app
+```
+::::
+
+::::{step} Confirm that EDOT Python is working
+To confirm that EDOT Python has successfully connected to Elastic:
+
+1. Go to **Observability** → **Applications** → **Service Inventory**
+2. Find the name of the service to which you just added EDOT Python. It can take several minutes after initializing EDOT Python for the service to show up in this list.
+3. Select the name in the list to see trace data.
+
+:::{note}
+There might be no trace data to visualize unless you have invoked your application since initializing EDOT Python.
+:::
+::::
+
+::::::
+
+## Troubleshooting
+
+For help with common setup issues, refer to the [EDOT Python troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/python/index.md).

--- a/docs/reference/setup/k8s.md
+++ b/docs/reference/setup/k8s.md
@@ -1,0 +1,172 @@
+---
+navigation_title: Kubernetes
+description: Instrumenting Python applications with EDOT SDKs on Kubernetes.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Instrumenting Python applications with EDOT SDKs on Kubernetes
+
+Learn how to instrument Python applications on Kubernetes using the OpenTelemetry Operator, the {{edot}} (EDOT) Collector, and the EDOT Python SDK.
+
+- For general knowledge about the EDOT Python SDK, refer to the [EDOT Java Intro page](/reference/index.md).
+- For Python auto-instrumentation specifics, refer to [OpenTelemetry Operator Python auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#python).
+- To manually instrument your Python application code (by customizing spans and metrics), refer to [EDOT Python manual instrumentation](/reference/setup/manual-instrumentation.md).
+- For general information about instrumenting applications on Kubernetes, refer to [instrumenting applications on Kubernetes](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md).
+
+## Supported environments and configuration
+
+The following environments and configurations are supported:
+
+- EDOT Python container image supports `glibc` and `musl` based auto-instrumentation for Python 3.12.
+- `musl` based containers instrumentation requires an [extra annotation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#annotations-python-musl) and operator v0.113.0+.
+- To turn on logs auto-instrumentation, refer to [auto-instrument python logs](https://opentelemetry.io/docs/kubernetes/operator/automatic/#auto-instrumenting-python-logs).
+- To turn on specific instrumentation libraries, refer to [excluding auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#python-excluding-auto-instrumentation).
+- For a full list of configuration options, refer to [Python specific configuration](https://opentelemetry.io/docs/zero-code/python/configuration/#python-specific-configuration).
+- For Python specific limitations when using the OpenTelemetry operator, refer to [Python-specific topics](https://opentelemetry.io/docs/zero-code/python/operator/#python-specific-topics).
+
+## Instrument a Python app on Kubernetes
+
+Following this example, you can learn how to:
+
+- Turn on auto-instrumentation of a Python application using one of the following supported methods:
+  - Adding an annotation to the deployment Pods.
+  - Adding an annotation to the namespace.
+- Verify that auto-instrumentation libraries are injected and configured correctly.
+- Confirm data is flowing to **{{kib}} Observability**.
+
+For this example, we assume the application you're instrumenting is a deployment named `python-app` running in the `python-ns` namespace.
+
+1. Ensure you have successfully [installed the OpenTelemetry Operator](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/deployment.md), and confirm that the following `Instrumentation` object exists in the system:
+
+    ```bash
+    $ kubectl get instrumentation -n opentelemetry-operator-system
+    NAME                      AGE    ENDPOINT
+    elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
+    ```
+
+    :::{note}
+    If your `Instrumentation` object has a different name or is created in a different namespace, you will have to adapt the annotation value in the next step.
+    :::
+
+2. Turn on auto-instrumentation of the Python application using one of the following methods:
+
+    - Edit your application workload definition and include the annotation under `spec.template.metadata.annotations`:
+
+        ```yaml
+        spec:
+        # ...
+        template:
+            metadata:
+            labels:
+                app: python-app
+            annotations:
+                instrumentation.opentelemetry.io/inject-python: opentelemetry-operator-system/elastic-instrumentation
+        # ...
+        ```
+
+    - Alternatively, add the annotation at namespace level to apply auto-instrumentation in all Pods of the namespace:
+
+        ```bash
+        kubectl annotate namespace python-ns instrumentation.opentelemetry.io/inject-python=opentelemetry-operator-system/elastic-instrumentation
+        ```
+
+3. Restart the application:
+
+    After the annotation has been set, restart the application to create new Pods and inject the instrumentation libraries:
+
+        ```bash
+        kubectl rollout restart deployment python-app -n python-ns
+        ```
+
+4. Verify the [auto-instrumentation resources](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md#how-auto-instrumentation-works) are injected in the Pod:
+
+    Run a `kubectl describe` of one of your application pods and check:
+
+    - There should be an init container named `opentelemetry-auto-instrumentation-python` in the Pod:
+
+        ```bash
+        $ kubectl describe pod python-app-8d84c47b8-8h5z2 -n python-ns
+        ...
+        ...
+        Init Containers:
+        opentelemetry-auto-instrumentation-python:
+            Container ID:  containerd://fdc86b3191e34ef5ec872853b14a950d0af1e36b0bc207f3d59bd50dd3caafe9
+            Image:         docker.elastic.co/observability/elastic-otel-python:0.3.0
+            Image ID:      docker.elastic.co/observability/elastic-otel-python@sha256:de7b5cce7514a10081a00820a05097931190567ec6e18a384ff7c148bad0695e
+            Port:          <none>
+            Host Port:     <none>
+            Command:
+            cp
+            -r
+            /autoinstrumentation/.
+            /otel-auto-instrumentation-python
+            State:          Terminated
+            Reason:       Completed
+        ...
+        ```
+
+    - The main container has new environment variables, including `PYTHONPATH`:
+
+        ```bash
+        ...
+        Containers:
+        python-app:
+        ...
+            Environment:
+        ...
+            PYTHONPATH:                          /otel-auto-instrumentation-python/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation-python
+            OTEL_EXPORTER_OTLP_PROTOCOL:         http/protobuf
+            OTEL_TRACES_EXPORTER:                otlp
+            OTEL_METRICS_EXPORTER:               otlp
+            OTEL_SERVICE_NAME:                   python-app
+            OTEL_EXPORTER_OTLP_ENDPOINT:         http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
+        ...
+        ```
+
+    - The Pod has an `EmptyDir` volume named `opentelemetry-auto-instrumentation-python` mounted in both the main and the init containers in path `/otel-auto-instrumentation-python`:
+
+        ```bash
+        Init Containers:
+        opentelemetry-auto-instrumentation-python:
+        ...
+            Mounts:
+            /otel-auto-instrumentation-python from opentelemetry-auto-instrumentation-python (rw)
+        Containers:
+        python-app:
+        ...
+            Mounts:
+            /otel-auto-instrumentation-python from opentelemetry-auto-instrumentation-python (rw)
+        ...
+        Volumes:
+        ...
+        opentelemetry-auto-instrumentation-python:
+            Type:        EmptyDir (a temporary directory that shares a pod's lifetime)
+        ```
+
+    Make sure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
+
+5. Confirm data is flowing to **{{kib}}**:
+
+    - Open **Observability** → **Applications** → **Service inventory**, and determine if:
+        - The application appears in the list of services.
+        - The application shows transactions and metrics.
+        - If [python logs instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#auto-instrumenting-python-logs) is enabled, the application logs should  appear in the Logs tab.
+
+    - For application container logs, open **{{kib}} Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
+        - `k8s.deployment.name: "python-app"` (adapt the query filter to your use case)
+        - `k8s.pod.name: python-app*` (adapt the query filter to your use case)
+
+    Note that the container logs are not provided by the instrumentation library, but by the DaemonSet collector deployed as part of the [operator installation](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/deployment.md).
+
+## Troubleshooting
+
+Refer to [troubleshoot auto-instrumentation](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md#troubleshooting-auto-instrumentation) for further analysis.

--- a/docs/reference/setup/manual-instrumentation.md
+++ b/docs/reference/setup/manual-instrumentation.md
@@ -1,0 +1,102 @@
+---
+navigation_title: Manual instrumentation
+description: Learn how to manually instrument Python applications using the {{edot}} Python SDK to add spans, metrics, and custom attributes. 
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Manual instrumentation for Python with EDOT SDK
+
+Learn how to manually instrument Python applications using the {{edot}} Python SDK to add spans, metrics, and custom attributes. The following instructions require auto-instrumentation with OpenTelemetry to have been added to your application per [Setup](/reference/setup/index.md).
+
+## Configure EDOT Python
+
+Refer to our [Setup](/reference/setup/index.md) page for more details.
+
+## Manually instrument your auto-instrumented Python application
+
+The following example shows how to add manual instrumentation to an already automatically instrumented application. A use case for this setup would be to trace something in particular while keeping the benefits of the simplicity of the automatic instrumentation doing the hard work for you.
+
+As an example we'll use an application using the Flask framework that implements an endpoint mounted on `/hello` returning a friendly salute. This application is saved in a file named `app.py` that is the default module for Flask applications.
+
+```python
+import random
+
+from flask import Flask
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+app = Flask(__name__)
+
+@app.route("/hello")
+def hello():
+    choices = ["there", "world", "folks", "hello"]
+    # create a span for the choice of the name, this may be a costly call in your real world application
+    with tracer.start_as_current_span("choice") as span:
+        choice = random.choice(choices)
+        span.set_attribute("choice.value", choice)
+    return f"Hello {choice}!"
+```
+
+Make sure to have Flask and the Flask OpenTelemetry instrumentation installed:
+
+```bash
+pip install flask
+edot-bootstrap --action=install
+```
+
+Then run this application with the following command:
+
+```bash
+opentelemetry-instrument flask run
+```
+
+You might not only need to add a custom span to our application but also want to use a custom metric, like in the next example, where you are tracking how many times we are getting one of the possible choices for our salutes:
+
+```python
+import random
+
+from flask import Flask
+from opentelemetry import metrics, trace
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+hello_counter = meter.create_counter(
+    "hello.choice",
+    description="The number of times a salute is chosen",
+)
+
+app = Flask(__name__)
+
+@app.route("/hello")
+def hello():
+    choices = ["there", "world", "folks", "hello"]
+    # create a span for the choice of the name, this may be a costly call in your real world application
+    with tracer.start_as_current_span("choice") as span:
+        choice = random.choice(choices)
+        span.set_attribute("choice.value", choice)
+    hello_counter.add(1, {"choice.value": choice})
+    return f"Hello {choice}!"
+```
+
+## Confirm that EDOT Python is working
+
+To confirm that EDOT Python has successfully connected to Elastic:
+
+1. Go to **Observability** → **Applications** → **Service Inventory**
+1. Find the name of the service to which you just added EDOT Python. It can take several minutes after initializing EDOT Python for the service to show up in this list.
+1. Select the name in the list to see trace data.
+
+:::{note}
+There might be no trace data to visualize unless you have used your application since initializing EDOT Python.
+:::

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -1,0 +1,122 @@
+---
+navigation_title: Supported Technologies
+description: Technologies Supported by the EDOT Python SDK.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_python: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Technologies supported by EDOT Python
+
+EDOT Python is a [distribution](https://opentelemetry.io/docs/concepts/distributions/) of OpenTelemetry Python. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies of the OpenTelemetry Python.
+
+## EDOT Collector and Elastic Stack versions
+
+EDOT Python sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of the EDOT Collector, for full support use either [EDOT Collector](elastic-agent://reference/edot-collector/index.md) versions 9.x or {{serverless-full}} for OTLP ingest.
+
+:::{note}
+Ingesting data from EDOT SDKs through EDOT Collector 9.x into Elastic Stack versions 8.18+ is supported.
+:::
+
+Refer to [EDOT SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
+
+## Python versions
+
+The following Python versions are supported:
+
+ * 3.9
+ * 3.10
+ * 3.11
+ * 3.12
+ * 3.13
+
+This follows the [OpenTelemetry Python Version Support](https://github.com/open-telemetry/opentelemetry-python/?tab=readme-ov-file#python-version-support).
+
+## Instrumentations
+
+Instrumentations are not installed by default. Use the [edot-bootstrap](/reference/setup/index.md) command to automatically install the available instrumentations.
+
+| Name | Packages instrumented | Semantic conventions status |
+|---|---|---|---|
+| [elastic-opentelemetry-instrumentation-openai](https://github.com/elastic/elastic-otel-python-instrumentations/blob/main/instrumentation/elastic-opentelemetry-instrumentation-openai) | openai >= 1.2.0 | development
+| [opentelemetry-instrumentation-aio-pika](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aio-pika) | aio_pika >= 7.2.0, < 10.0.0 | development
+| [opentelemetry-instrumentation-aiohttp-client](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiohttp-client) | aiohttp ~= 3.0 | migration
+| [opentelemetry-instrumentation-aiohttp-server](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiohttp-server) | aiohttp ~= 3.0 | development
+| [opentelemetry-instrumentation-aiokafka](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiokafka) | aiokafka >= 0.8, < 1.0 | development
+| [opentelemetry-instrumentation-aiopg](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aiopg) | aiopg >= 0.13.0, < 2.0.0 | development
+| [opentelemetry-instrumentation-asgi](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi) | asgiref ~= 3.0 | migration
+| [opentelemetry-instrumentation-asyncclick](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asyncclick) | asyncclick ~= 8.0 | development
+| [opentelemetry-instrumentation-asyncio](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asyncio) | asyncio | development
+| [opentelemetry-instrumentation-asyncpg](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asyncpg) | asyncpg >= 0.12.0 | development
+| [opentelemetry-instrumentation-aws-lambda](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aws-lambda) | | development
+| [opentelemetry-instrumentation-boto](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-boto) | boto~=2.0 | development
+| [opentelemetry-instrumentation-boto3sqs](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-boto3sqs) | boto3 ~= 1.0 | development
+| [opentelemetry-instrumentation-botocore](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-botocore) | botocore ~= 1.0 | development
+| [opentelemetry-instrumentation-cassandra](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-cassandra) | cassandra-driver ~= 3.25,scylla-driver ~= 3.25 | development
+| [opentelemetry-instrumentation-celery](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-celery) | celery >= 4.0, < 6.0 | development
+| [opentelemetry-instrumentation-click](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-click) | click >= 8.1.3, < 9.0.0 | development
+| [opentelemetry-instrumentation-confluent-kafka](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-confluent-kafka) | confluent-kafka >= 1.8.2, <= 2.7.0 | development
+| [opentelemetry-instrumentation-dbapi](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-dbapi) | dbapi | development
+| [opentelemetry-instrumentation-django](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-django) | django >= 1.10 | development
+| [opentelemetry-instrumentation-elasticsearch](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-elasticsearch) | elasticsearch >= 6.0 | development
+| [opentelemetry-instrumentation-falcon](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-falcon) | falcon >= 1.4.1, < 5.0.0 | migration
+| [opentelemetry-instrumentation-fastapi](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-fastapi) | fastapi ~= 0.92 | migration
+| [opentelemetry-instrumentation-flask](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-flask) | flask >= 1.0 | migration
+| [opentelemetry-instrumentation-grpc](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-grpc) | grpcio >= 1.42.0 | development
+| [opentelemetry-instrumentation-httpx](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-httpx) | httpx >= 0.18.0 | migration
+| [opentelemetry-instrumentation-jinja2](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-jinja2) | jinja2 >= 2.7, < 4.0 | development
+| [opentelemetry-instrumentation-kafka-python](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-kafka-python) | kafka-python >= 2.0, < 3.0,kafka-python-ng >= 2.0, < 3.0 | development
+| [opentelemetry-instrumentation-logging](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-logging) | logging | development
+| [opentelemetry-instrumentation-mysql](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-mysql) | mysql-connector-python >= 8.0, < 10.0 | development
+| [opentelemetry-instrumentation-mysqlclient](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-mysqlclient) | mysqlclient < 3 | development
+| [opentelemetry-instrumentation-pika](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pika) | pika >= 0.12.0 | development
+| [opentelemetry-instrumentation-psycopg](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-psycopg) | psycopg >= 3.1.0 | development
+| [opentelemetry-instrumentation-psycopg2](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-psycopg2) | psycopg2 >= 2.7.3.1,psycopg2-binary >= 2.7.3.1 | development
+| [opentelemetry-instrumentation-pymemcache](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymemcache) | pymemcache >= 1.3.5, < 5 | development
+| [opentelemetry-instrumentation-pymongo](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymongo) | pymongo >= 3.1, < 5.0 | development
+| [opentelemetry-instrumentation-pymssql](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymssql) | pymssql >= 2.1.5, < 3 | development
+| [opentelemetry-instrumentation-pymysql](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pymysql) | PyMySQL < 2 | development
+| [opentelemetry-instrumentation-pyramid](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-pyramid) | pyramid >= 1.7 | development
+| [opentelemetry-instrumentation-redis](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-redis) | redis >= 2.6 | development
+| [opentelemetry-instrumentation-remoulade](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-remoulade) | remoulade >= 0.50 | development
+| [opentelemetry-instrumentation-requests](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-requests) | requests ~= 2.0 | migration
+| [opentelemetry-instrumentation-sqlalchemy](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-sqlalchemy) | sqlalchemy >= 1.0.0, < 2.1.0 | development
+| [opentelemetry-instrumentation-sqlite3](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-sqlite3) | sqlite3 | development
+| [opentelemetry-instrumentation-starlette](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-starlette) | starlette >= 0.13 | development
+| [opentelemetry-instrumentation-system-metrics](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-system-metrics) | psutil >= 5 | development
+| [opentelemetry-instrumentation-threading](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-threading) | threading | development
+| [opentelemetry-instrumentation-tornado](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-tornado) | tornado >= 5.1.1 | development
+| [opentelemetry-instrumentation-tortoiseorm](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-tortoiseorm) | tortoise-orm >= 0.17.0 | development
+| [opentelemetry-instrumentation-urllib](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib) | urllib | migration
+| [opentelemetry-instrumentation-urllib3](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3) | urllib3 >= 1.0.0, < 3.0.0 | migration
+| [opentelemetry-instrumentation-vertexai](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai/opentelemetry-instrumentation-vertexai) | google-cloud-aiplatform >= 1.64 | development
+| [opentelemetry-instrumentation-wsgi](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-wsgi) | wsgi | migration
+
+The semantic conventions status tracks the stabilization of the semantic conventions used in the instrumentation:
+
+- Stable means they are stable and are not expected to change.
+- Development means they are not stable yet and they may change in the future.
+- Migration means there may be configuration knobs to switch between different semantic conventions.
+
+### Native Elasticsearch instrumentation
+
+Some libraries like the Python {{es}} Client natively supports OpenTelemetry instrumentation.
+
+The [elasticsearch](https://elasticsearch-py.readthedocs.io/en/latest/) package has native OpenTelemetry support since version 8.13.
+
+### LLM instrumentations
+
+You can instrument the following LLM (Large Language Model) libraries with instrumentations implementing the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+
+| **SDK**                     | **Instrumentation**                          | **Traces**   | **Metrics**     | **Logs**       | **Notes**                                                                                                                                                                                                                     |
+|-----------------------------|----------------------------------------------|--------------|-----------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| OpenAI                      | [elastic-opentelemetry-instrumentation-openai](https://github.com/elastic/elastic-otel-python-instrumentations/blob/main/instrumentation/elastic-opentelemetry-instrumentation-openai) | Supported    | Supported       | Supported      | Supports sync and async [chat completions create](https://platform.openai.com/docs/guides/text?api-mode=chat) API and [embeddings](https://platform.openai.com/docs/guides/embeddings?lang=python) API.                      |
+| AWS SDK for Python (Boto3)  | [opentelemetry-instrumentation-botocore](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-botocore)              | Supported    | Supported       | Supported      | Supports [Bedrock Runtime](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime.html) APIs like [InvokeModel](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html), [InvokeModelWithResponseStream](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelWithResponseStream.html), [Converse](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html), and [ConverseStream](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html). A subset of models are traced in InvokeModel and InvokeModelWithStreaming API. See [botocore instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-botocore#bedrock-runtime). |
+| Google Cloud AI Platform    | [opentelemetry-instrumentation-vertexai](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai/opentelemetry-instrumentation-vertexai)        | Supported    | Experimental    | Supported      | Instrumentation supports tracing and sending events for synchronous API calls. Currently, it doesn't support async APIs and streaming calls.                                           |

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -1,0 +1,11 @@
+toc:
+  - file: index.md
+    children:
+      - file: setup/index.md
+        children:
+          - file: setup/k8s.md
+          - file: setup/manual-instrumentation.md
+      - file: configuration.md
+      - file: supported-technologies.md
+      - file: migration.md
+      - file: overhead.md

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -9,3 +9,5 @@ toc:
       - file: supported-technologies.md
       - file: migration.md
       - file: overhead.md
+      - title: Troubleshooting
+        crosslink: docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/python/index.md


### PR DESCRIPTION
This PR contributes to https://github.com/elastic/opentelemetry-dev/issues/1044

It brings back the reference documentation and adds a nav crosslink to the troubleshooting docs.

We're assuming here that the EDOT Collector documentation will be served from the `main` branch, following cumulative docs best practices.