### PR TITLE
config: add handling of ReportFullState ServerToAgent flag

### DIFF
--- a/src/elasticotel/distro/config.py
+++ b/src/elasticotel/distro/config.py
@@ -132,10 +132,10 @@ def _get_config():
 
 
 def opamp_handler(agent: OpAMPAgent, client: OpAMPClient, message: opamp_pb2.ServerToAgent):
-    # server wants us to report full state because usually it cannot recognize us as agent because
+    # server wants us to report full state as it cannot recognize us as agent because
     # e.g it may have been restarted and lost state.
     if _report_full_state(message):
-        # here we're not returning explcitly but usually we don't get a remote config when we get the flag set
+        # here we're not returning explicitly but usually we don't get a remote config when we get the flag set
         payload = client._build_full_state_message()
         agent.send(payload=payload)
 

--- a/src/elasticotel/distro/config.py
+++ b/src/elasticotel/distro/config.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass
 
 from opentelemetry import trace
 
@@ -27,7 +30,7 @@ from opentelemetry._opamp.proto import opamp_pb2 as opamp_pb2
 
 logger = logging.getLogger(__name__)
 
-_LOG_LEVELS_MAP = {
+_LOG_LEVELS_MAP: dict[str, int] = {
     "trace": 5,
     "debug": logging.DEBUG,
     "info": logging.INFO,
@@ -38,16 +41,40 @@ _LOG_LEVELS_MAP = {
 }
 
 DEFAULT_SAMPLING_RATE = 1.0
+DEFAULT_LOGGING_LEVEL = "info"
+
+LOGGING_LEVEL_CONFIG_KEY = "logging_level"
+SAMPLING_RATE_CONFIG_KEY = "sampling_rate"
 
 
-def _handle_logging_level(config) -> str:
-    error_message = ""
+@dataclass
+class ConfigItem:
+    value: str
+
+
+@dataclass
+class ConfigUpdate:
+    error_message: str = ""
+
+
+# TODO: this should grow into a proper configuration store initialized from env vars and so on
+@dataclass
+class Config:
+    sampling_rate = ConfigItem(value=str(DEFAULT_SAMPLING_RATE))
+    logging_level = ConfigItem(value=DEFAULT_LOGGING_LEVEL)
+
+    def to_dict(self):
+        return {LOGGING_LEVEL_CONFIG_KEY: self.logging_level.value, SAMPLING_RATE_CONFIG_KEY: self.sampling_rate.value}
+
+
+_config = Config()
+
+
+def _handle_logging_level(remote_config) -> ConfigUpdate:
+    _config = _get_config()
     # when config option has default value you don't get it so need to handle the default
-    config_logging_level = config.get("logging_level")
-    if config_logging_level is not None:
-        logging_level = _LOG_LEVELS_MAP.get(config_logging_level)  # type: ignore[reportArgumentType]
-    else:
-        logging_level = logging.INFO
+    config_logging_level = remote_config.get(LOGGING_LEVEL_CONFIG_KEY, DEFAULT_LOGGING_LEVEL)
+    logging_level = _LOG_LEVELS_MAP.get(config_logging_level)
 
     if logging_level is None:
         logger.error("Logging level not handled: %s", config_logging_level)
@@ -56,11 +83,14 @@ def _handle_logging_level(config) -> str:
         # update upstream and distro logging levels
         logging.getLogger("opentelemetry").setLevel(logging_level)
         logging.getLogger("elasticotel").setLevel(logging_level)
-    return error_message
+        _config.logging_level = ConfigItem(value=config_logging_level)
+        error_message = ""
+    return ConfigUpdate(error_message=error_message)
 
 
-def _handle_sampling_rate(config) -> str:
-    config_sampling_rate = config.get("sampling_rate")
+def _handle_sampling_rate(remote_config) -> ConfigUpdate:
+    _config = _get_config()
+    config_sampling_rate = remote_config.get(SAMPLING_RATE_CONFIG_KEY, str(DEFAULT_SAMPLING_RATE))
     sampling_rate = DEFAULT_SAMPLING_RATE
     if config_sampling_rate is not None:
         try:
@@ -69,17 +99,17 @@ def _handle_sampling_rate(config) -> str:
                 raise ValueError()
         except ValueError:
             logger.error("Invalid `sampling_rate` from config `%s`", config_sampling_rate)
-            return f"Invalid sampling_rate {config_sampling_rate}"
+            return ConfigUpdate(error_message=f"Invalid sampling_rate {config_sampling_rate}")
 
     sampler = getattr(trace.get_tracer_provider(), "sampler", None)
     if sampler is None:
         logger.debug("Cannot get sampler from tracer provider.")
-        return ""
+        return ConfigUpdate()
 
     # FIXME: this needs to be updated for the consistent probability samplers
     if not isinstance(sampler, ParentBasedTraceIdRatio):
         logger.warning("Sampler %s is not supported, not applying sampling_rate.", type(sampler))
-        return ""
+        return ConfigUpdate()
 
     # since sampler is parent based we need to update its root sampler
     root_sampler = sampler._root  # type: ignore[reportAttributeAccessIssue]
@@ -88,32 +118,55 @@ def _handle_sampling_rate(config) -> str:
         root_sampler._rate = sampling_rate  # type: ignore[reportAttributeAccessIssue]
         root_sampler._bound = root_sampler.get_bound_for_rate(root_sampler._rate)  # type: ignore[reportAttributeAccessIssue]
         logger.debug("Updated sampler rate to %s", sampling_rate)
-    return ""
+        _config.sampling_rate = ConfigItem(value=config_sampling_rate)
+    return ConfigUpdate()
+
+
+def _report_full_state(message: opamp_pb2.ServerToAgent):
+    return message.flags & opamp_pb2.ServerToAgentFlags_ReportFullState
+
+
+def _get_config():
+    global _config
+    return _config
 
 
 def opamp_handler(agent: OpAMPAgent, client: OpAMPClient, message: opamp_pb2.ServerToAgent):
+    # server wants us to report full state because usually it cannot recognize us as agent because
+    # e.g it may have been restarted and lost state.
+    if _report_full_state(message):
+        # here we're not returning explcitly but usually we don't get a remote config when we get the flag set
+        payload = client._build_full_state_message()
+        agent.send(payload=payload)
+
     # we check config_hash because we need to track last received config and remote_config seems to be always truthy
     if not message.remote_config or not message.remote_config.config_hash:
         return
 
+    _config = _get_config()
     error_messages = []
-    for config_filename, config in messages._decode_remote_config(message.remote_config):
+    for config_filename, remote_config in messages._decode_remote_config(message.remote_config):
         # we don't have standardized config values so limit to configs coming from our backend
         if config_filename == "elastic":
-            logger.debug("Config %s: %s", config_filename, config)
-            error_message = _handle_logging_level(config)
-            if error_message:
-                error_messages.append(error_message)
+            logger.debug("Config %s: %s", config_filename, remote_config)
+            config_update = _handle_logging_level(remote_config)
+            if config_update.error_message:
+                error_messages.append(config_update.error_message)
 
-            error_message = _handle_sampling_rate(config)
-            if error_message:
-                error_messages.append(error_message)
+            config_update = _handle_sampling_rate(remote_config)
+            if config_update.error_message:
+                error_messages.append(config_update.error_message)
 
     error_message = "\n".join(error_messages)
     status = opamp_pb2.RemoteConfigStatuses_FAILED if error_message else opamp_pb2.RemoteConfigStatuses_APPLIED
     updated_remote_config = client._update_remote_config_status(
         remote_config_hash=message.remote_config.config_hash, status=status, error_message=error_message
     )
+
+    # update the cached effective config with what we updated
+    effective_config = {"elastic": _config.to_dict()}
+    client._update_effective_config(effective_config)
+
     # if we changed the config send an ack to the server so we don't receive the same config at every heartbeat response
     if updated_remote_config is not None:
         payload = client._build_remote_config_status_response_message(updated_remote_config)

--- a/src/opentelemetry/_opamp/client.py
+++ b/src/opentelemetry/_opamp/client.py
@@ -47,6 +47,7 @@ _HANDLED_CAPABILITIES = (
     | opamp_pb2.AgentCapabilities.AgentCapabilities_ReportsHeartbeat
     | opamp_pb2.AgentCapabilities.AgentCapabilities_AcceptsRemoteConfig
     | opamp_pb2.AgentCapabilities.AgentCapabilities_ReportsRemoteConfig
+    | opamp_pb2.AgentCapabilities.AgentCapabilities_ReportsEffectiveConfig
 )
 
 
@@ -74,6 +75,7 @@ class OpAMPClient:
         self._sequence_num: int = 0
         self._instance_uid: bytes = uuid7().bytes
         self._remote_config_status: opamp_pb2.RemoteConfigStatus | None = None
+        self._effective_config: opamp_pb2.EffectiveConfig | None = None
 
     def _build_connection_message(self) -> bytes:
         message = messages._build_presentation_message(
@@ -100,6 +102,10 @@ class OpAMPClient:
         )
         data = messages._encode_message(message)
         return data
+
+    def _update_effective_config(self, effective_config: dict[str, dict[str, str]]) -> opamp_pb2.EffectiveConfig:
+        self._effective_config = messages._build_effective_config_message(effective_config)
+        return self._effective_config
 
     def _update_remote_config_status(
         self, remote_config_hash: bytes, status: opamp_pb2.RemoteConfigStatuses.ValueType, error_message: str = ""
@@ -128,6 +134,18 @@ class OpAMPClient:
             sequence_num=self._sequence_num,
             capabilities=_HANDLED_CAPABILITIES,
             remote_config_status=remote_config_status,
+        )
+        data = messages._encode_message(message)
+        return data
+
+    def _build_full_state_message(self) -> bytes:
+        message = messages._build_full_state_message(
+            instance_uid=self._instance_uid,
+            agent_description=self._agent_description,
+            remote_config_status=self._remote_config_status,
+            sequence_num=self._sequence_num,
+            effective_config=self._effective_config,
+            capabilities=_HANDLED_CAPABILITIES,
         )
         data = messages._encode_message(message)
         return data

--- a/src/opentelemetry/_opamp/messages.py
+++ b/src/opentelemetry/_opamp/messages.py
@@ -115,6 +115,36 @@ def _build_remote_config_status_response_message(
     return command
 
 
+def _build_effective_config_message(config: dict[str, dict[str, str]]):
+    agent_config_map = opamp_pb2.AgentConfigMap()
+    for filename, value in config.items():
+        body = json.dumps(value)
+        agent_config_map.config_map[filename].body = body.encode("utf-8")
+        agent_config_map.config_map[filename].content_type = "application/json"
+    return opamp_pb2.EffectiveConfig(
+        config_map=agent_config_map,
+    )
+
+
+def _build_full_state_message(
+    instance_uid: bytes,
+    sequence_num: int,
+    agent_description: opamp_pb2.AgentDescription,
+    capabilities: int,
+    remote_config_status: opamp_pb2.RemoteConfigStatus | None,
+    effective_config: opamp_pb2.EffectiveConfig | None,
+) -> opamp_pb2.AgentToServer:
+    command = opamp_pb2.AgentToServer(
+        instance_uid=instance_uid,
+        sequence_num=sequence_num,
+        agent_description=agent_description,
+        remote_config_status=remote_config_status,
+        effective_config=effective_config,
+        capabilities=capabilities,
+    )
+    return command
+
+
 def _encode_message(data: opamp_pb2.AgentToServer) -> bytes:
     return data.SerializeToString()
 

--- a/tests/opamp/README.md
+++ b/tests/opamp/README.md
@@ -1,0 +1,96 @@
+# How to record e2e tests
+
+We use [VCR.py](https://vcrpy.readthedocs.io/en/latest/) to automatically record HTTP responses from
+an OpAMP server.
+
+We use a build of [opentelemetry-collector-components](https://github.com/elastic/opentelemetry-collector-components/) as
+OpAMP server. To build on a linux machine run:
+
+`make genelasticcol`
+
+You then need an Elastic Cloud Deployment setup, an APIKey and the ElasticSearch endpoint URL.
+
+
+You can use the following configuration:
+
+```
+extensions:
+  bearertokenauth:
+    scheme: "APIKey"
+    token: "<api key>"
+  apmconfig:
+   source:
+    elasticsearch:
+      endpoint: "<es endpoint>"
+      auth:
+        authenticator: bearertokenauth
+      cache_duration: 10s
+   opamp:
+     protocols:
+       http:
+         endpoint: "localhost:4320"
+
+receivers:
+  # Receiver for logs, traces, and metrics from SDKs
+  otlp/fromsdk:
+    protocols:
+      grpc:
+      http:
+
+  elasticapm:
+
+processors:
+  elasticapm:
+
+exporters:
+  elasticsearch/otel:
+    endpoints: ["<es endpoint>"]
+    auth:
+      authenticator: bearertokenauth
+    mapping:
+      mode: otel
+    logs_dynamic_index:
+      enabled: true
+    metrics_dynamic_index:
+      enabled: true
+    traces_dynamic_index:
+      enabled: true
+
+  debug:
+    verbosity: detailed
+
+service:
+  telemetry:
+    logs:
+      level: debug
+  extensions: [bearertokenauth, apmconfig]
+  pipelines:
+    traces/fromsdk:
+      receivers: [otlp/fromsdk]
+      processors: [elasticapm]
+      exporters: [elasticsearch/otel, debug]
+
+    metrics/fromsdk:
+      receivers: [otlp/fromsdk]
+      processors: [elasticapm]
+      exporters: [elasticsearch/otel]
+
+    metrics/aggregated-metrics:
+      receivers: [elasticapm]
+      processors: []
+      exporters: [elasticsearch/otel]
+
+    logs/fromsdk:
+      receivers: [otlp/fromsdk]
+      processors: [elasticapm]
+      exporters: [elasticsearch/otel]
+```
+
+And you can start a collector instance with:
+
+`./_build/elastic-collector-components --config config.yml`
+
+Now you need to send some OTLP data from a service with `service.name` set (`foo` is currently used in tests) so we can
+create an Agent configuration (`/app/apm/settings/agent-configuration/create`) for the very same `Service`.
+
+Once you have the configuration you can write a tests using the proper `service.name` as configured in the backend.

--- a/tests/opamp/README.md
+++ b/tests/opamp/README.md
@@ -93,4 +93,4 @@ And you can start a collector instance with:
 Now you need to send some OTLP data from a service with `service.name` set (`foo` is currently used in tests) so we can
 create an Agent configuration (`/app/apm/settings/agent-configuration/create`) for the very same `Service`.
 
-Once you have the configuration you can write a tests using the proper `service.name` as configured in the backend.
+Once you have the configuration you can write tests using the proper `service.name` as configured in the backend.

--- a/tests/opamp/cassettes/test_agent_send_full_state_when_asked.yaml
+++ b/tests/opamp/cassettes/test_agent_send_full_state_when_asked.yaml
@@ -1,0 +1,202 @@
+interactions:
+- request:
+    body: !!binary |
+      ChABmVwAJ+Z64rVrtpAgQo8VGj0KFQoMc2VydmljZS5uYW1lEgUKA2ZvbwokChtkZXBsb3ltZW50
+      LmVudmlyb25tZW50Lm5hbWUSBQoDZm9vIIdg
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '84'
+      Content-Type:
+      - application/x-protobuf
+      User-Agent:
+      - OTel-OpAMP-Python/0.0.1
+    method: POST
+    uri: http://localhost:4320/v1/opamp
+  response:
+    body:
+      string: !!binary |
+        ChABmVwAJ+Z64rVrtpAgQo8VGmYKOgo4CgdlbGFzdGljEi0KGXsibG9nZ2luZ19sZXZlbCI6ImRl
+        YnVnIn0SEGFwcGxpY2F0aW9uL2pzb24SKGY3MzA5M2VjZDEyNjkzZGMxNDUxYWQ2MjdlZDA2MWJl
+        ZWM5ZjU1OWM4AlIA
+    headers:
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/x-protobuf
+      Date:
+      - Thu, 18 Sep 2025 08:45:38 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      ChABmVwAJ+Z64rVrtpAgQo8VEAEgh2A6LAooZjczMDkzZWNkMTI2OTNkYzE0NTFhZDYyN2VkMDYx
+      YmVlYzlmNTU5YxAB
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/x-protobuf
+      User-Agent:
+      - OTel-OpAMP-Python/0.0.1
+    method: POST
+    uri: http://localhost:4320/v1/opamp
+  response:
+    body:
+      string: !!binary |
+        ChABmVwAJ+Z64rVrtpAgQo8VOAJSAA==
+    headers:
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/x-protobuf
+      Date:
+      - Thu, 18 Sep 2025 08:45:38 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      ChABmVwAJ+Z64rVrtpAgQo8VEAIgh2A=
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/x-protobuf
+      User-Agent:
+      - OTel-OpAMP-Python/0.0.1
+    method: POST
+    uri: http://localhost:4320/v1/opamp
+  response:
+    body:
+      string: !!binary |
+        ChABmVwAJ+Z64rVrtpAgQo8VOAJSAA==
+    headers:
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/x-protobuf
+      Date:
+      - Thu, 18 Sep 2025 08:45:39 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      ChABmVwAJ+Z64rVrtpAgQo8VEAMgh2A=
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/x-protobuf
+      User-Agent:
+      - OTel-OpAMP-Python/0.0.1
+    method: POST
+    uri: http://localhost:4320/v1/opamp
+  response:
+    body:
+      string: !!binary |
+        ChABmVwAJ+Z64rVrtpAgQo8VEm8SbWVycm9yIHJldHJpZXZpbmcgcmVtb3RlIGNvbmZpZ3VyYXRp
+        b246IGFnZW50IGNvdWxkIG5vdCBiZSBpZGVudGlmaWVkOiBzZXJ2aWNlLm5hbWUgYXR0cmlidXRl
+        IG11c3QgYmUgcHJvdmlkZWQwATgCUgA=
+    headers:
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/x-protobuf
+      Date:
+      - Thu, 18 Sep 2025 08:45:40 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      ChABmVwAJ+Z64rVrtpAgQo8VEAQaPQoVCgxzZXJ2aWNlLm5hbWUSBQoDZm9vCiQKG2RlcGxveW1l
+      bnQuZW52aXJvbm1lbnQubmFtZRIFCgNmb28gh2A6LAooZjczMDkzZWNkMTI2OTNkYzE0NTFhZDYy
+      N2VkMDYxYmVlYzlmNTU5YxAB
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/x-protobuf
+      User-Agent:
+      - OTel-OpAMP-Python/0.0.1
+    method: POST
+    uri: http://localhost:4320/v1/opamp
+  response:
+    body:
+      string: !!binary |
+        ChABmVwAJ+Z64rVrtpAgQo8VOAJSAA==
+    headers:
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/x-protobuf
+      Date:
+      - Thu, 18 Sep 2025 08:45:40 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      ChABmVwAJ+Z64rVrtpAgQo8VEAUgh2BKAA==
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/x-protobuf
+      User-Agent:
+      - OTel-OpAMP-Python/0.0.1
+    method: POST
+    uri: http://localhost:4320/v1/opamp
+  response:
+    body:
+      string: !!binary |
+        ChABmVwAJ+Z64rVrtpAgQo8VOAJSAA==
+    headers:
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/x-protobuf
+      Date:
+      - Thu, 18 Sep 2025 08:45:41 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/opamp/test_client.py
+++ b/tests/opamp/test_client.py
@@ -261,6 +261,69 @@ def test_build_remote_config_status_response_message_with_error_message(client):
     assert message.remote_config_status.error_message == "an error message"
 
 
+def test_update_effective_config(client):
+    config = {"filename": {"a": "config"}}
+    client._update_effective_config(config)
+
+    assert isinstance(client._effective_config, opamp_pb2.EffectiveConfig)
+
+    decoded_config = {}
+    for file_name, config_file in client._effective_config.config_map.config_map.items():
+        body = config_file.body.decode()
+        decoded_config[file_name] = json.loads(body)
+
+    assert config == decoded_config
+
+
+def test_build_full_state_message(client):
+    client._update_remote_config_status(
+        remote_config_hash=b"12345678",
+        status=opamp_pb2.RemoteConfigStatuses_APPLIED,
+    )
+    config = {"filename": {"a": "config"}}
+    client._update_effective_config(config)
+
+    data = client._build_full_state_message()
+
+    message = opamp_pb2.AgentToServer()
+    message.ParseFromString(data)
+
+    assert message
+    assert message.instance_uid == client._instance_uid
+    assert message.sequence_num == 0
+    assert message.capabilities == _HANDLED_CAPABILITIES
+    assert message.agent_description.identifying_attributes == [
+        PB2KeyValue(key="foo", value=PB2AnyValue(string_value="bar")),
+    ]
+    assert message.remote_config_status
+    assert message.remote_config_status.last_remote_config_hash == b"12345678"
+    assert message.remote_config_status.status == opamp_pb2.RemoteConfigStatuses_APPLIED
+    assert "filename" in message.effective_config.config_map.config_map
+    config_file = message.effective_config.config_map.config_map["filename"]
+    assert config_file.content_type == "application/json"
+    body = config_file.body.decode()
+    assert config["filename"] == json.loads(body)
+
+
+def test_build_full_state_message_no_config(client):
+    data = client._build_full_state_message()
+
+    message = opamp_pb2.AgentToServer()
+    message.ParseFromString(data)
+
+    assert message
+    assert message.instance_uid == client._instance_uid
+    assert message.sequence_num == 0
+    assert message.capabilities == _HANDLED_CAPABILITIES
+    assert message.agent_description.identifying_attributes == [
+        PB2KeyValue(key="foo", value=PB2AnyValue(string_value="bar")),
+    ]
+    assert message.remote_config_status
+    assert message.remote_config_status.last_remote_config_hash == b""
+    assert message.remote_config_status.status == opamp_pb2.RemoteConfigStatuses_UNSET
+    assert message.effective_config.config_map.config_map == {}
+
+
 def test_message_sequence_num_increases_in_send(client):
     client._transport = mock.Mock()
     for i in range(2):

--- a/tests/opamp/test_e2e.py
+++ b/tests/opamp/test_e2e.py
@@ -47,8 +47,8 @@ def test_connection_remote_config_status_heartbeat_disconnection(caplog):
         )
         if updated_remote_config is not None:
             logger.debug("Updated Remote Config")
-            message = client._build_remote_config_status_response_message(updated_remote_config)
-            agent.send(payload=message)
+            payload = client._build_remote_config_status_response_message(updated_remote_config)
+            agent.send(payload=payload)
 
     opamp_client = OpAMPClient(
         endpoint="http://localhost:4320/v1/opamp",
@@ -105,3 +105,75 @@ def test_with_server_not_responding(caplog):
     opamp_agent.stop()
 
     assert opamp_handler.call_count == 0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="vcr.py not working with urllib 2 and older Pythons")
+@pytest.mark.vcr()
+def test_agent_send_full_state_when_asked(caplog):
+    caplog.set_level(logging.DEBUG, logger="opentelemetry._opamp.agent")
+
+    def opamp_handler(agent, client, message):
+        logger = logging.getLogger("opentelemetry._opamp.agent.opamp_handler")
+
+        logger.debug("In opamp_handler")
+
+        if message.flags & opamp_pb2.ServerToAgentFlags_ReportFullState:
+            logger.debug("Sent Full State")
+            payload = client._build_full_state_message()
+            agent.send(payload=payload)
+
+        # we need to update the config only if we have a config
+        if not message.remote_config.config_hash:
+            return
+
+        updated_remote_config = client._update_remote_config_status(
+            remote_config_hash=message.remote_config.config_hash,
+            status=opamp_pb2.RemoteConfigStatuses_APPLIED,
+            error_message="",
+        )
+        if updated_remote_config is not None:
+            logger.debug("Updated Remote Config")
+            payload = client._build_remote_config_status_response_message(updated_remote_config)
+            agent.send(payload=payload)
+
+    opamp_client = OpAMPClient(
+        endpoint="http://localhost:4320/v1/opamp",
+        agent_identifying_attributes={
+            "service.name": "foo",
+            "deployment.environment.name": "foo",
+        },
+    )
+    opamp_agent = OpAMPAgent(
+        interval=1,
+        message_handler=opamp_handler,
+        client=opamp_client,
+    )
+    opamp_agent.start()
+
+    # this should be enough for the heartbeat message to be sent
+    sleep(1)
+
+    # when recording tests here you should restart your collector with
+    # os.kill(<pid of server>, signal.SIGHUP)
+
+    # here the server has been restarted, wait for more heartbeats
+    sleep(2)
+
+    opamp_agent.stop()
+
+    handler_records = [
+        record[2] for record in caplog.record_tuples if record[0] == "opentelemetry._opamp.agent.opamp_handler"
+    ]
+    # If you look at the agent debug messages you'll see that after the restart the server will error about
+    # not being able to identify the agent while setting the ReportFullState flag and then being happy again
+    # after we send it.
+    assert handler_records == [
+        "In opamp_handler",
+        "Updated Remote Config",
+        "In opamp_handler",
+        "In opamp_handler",
+        "In opamp_handler",
+        "Sent Full State",
+        "In opamp_handler",
+        "In opamp_handler",
+    ]


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

This adds support for handling the case where the server gets restarted and loses the state about the agent. Now the agent will act on the ReportFullState ServerToAgent flag being set and will resend the full configuration so that the server can rebuild its state.
This also introduces a very simplified handling of effective config.

## Related issues

Closes #357 
