### PR TITLE
docs: update default sampler configuration

### DIFF
--- a/docs/reference/edot-python/configuration.md
+++ b/docs/reference/edot-python/configuration.md
@@ -129,7 +129,7 @@ EDOT Python uses different defaults than OpenTelemetry Python for the following 
 | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | `DELTA` | `CUMULATIVE` | |
 | `OTEL_LOG_LEVEL` | `warn` | | {applies_to}`edot_python: ga 1.9.0` |
 | `OTEL_METRICS_EXEMPLAR_FILTER` | `always_off` | `trace_based` | |
-| `OTEL_TRACES_SAMPLER` | `parentbased_traceidratio` | `parentbased_always_on` | {applies_to}`edot_python: ga 1.5.0` |
+| `OTEL_TRACES_SAMPLER` | `experimental_composite_parentbased_traceidratio` | `parentbased_always_on` | {applies_to}`edot_python: ga 1.10.0` , was `parentbased_traceidratio` since {applies_to}`edot_python: ga 1.5.0` |
 | `OTEL_TRACES_SAMPLER_ARG` | `1.0` | | {applies_to}`edot_python: ga 1.6.0`|
 
 :::{note}


### PR DESCRIPTION

## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It'll be `experimental_composite_parentbased_traceidratio` from 1.10.0


## Related issues
