### PR TITLE
Bump opentelemetry-opamp-client to 0.3b0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev --output-file=dev-requirements.txt --strip-extras pyproject.toml
 #
-build==1.5.1
+build==1.5.0
     # via pip-tools
 certifi==2026.6.17
     # via requests
@@ -60,7 +60,7 @@ opentelemetry-instrumentation-logging==0.64b0
     # via elastic-opentelemetry (pyproject.toml)
 opentelemetry-instrumentation-system-metrics==0.64b0
     # via elastic-opentelemetry (pyproject.toml)
-opentelemetry-opamp-client==0.2b0
+opentelemetry-opamp-client==0.3b0
     # via elastic-opentelemetry (pyproject.toml)
 opentelemetry-proto==1.43.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "opentelemetry-sdk == 1.43.0",
     "opentelemetry-sdk-extension-aws ~= 2.1.0",
     "opentelemetry-semantic-conventions == 0.64b0",
-    "opentelemetry-opamp-client == 0.2b0",
+    "opentelemetry-opamp-client == 0.3b0",
     "packaging",
     "uuid-utils",
 ]


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump to latest release, no changes required. The `build` version is downgraded because `1.5.1` got yanked.

## Related issues