### PR TITLE
docs: rename EDOT to Elastic OTel Python for 9.5 rebrand

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,4 @@
-project: 'EDOT Python release notes'
+project: 'Elastic OTel Python release notes'
 cross_links:
   - docs-content
   - opentelemetry
@@ -10,9 +10,9 @@ toc:
   - toc: reference/edot-python
 subs:
   motlp: Elastic Cloud Managed OTLP Endpoint
-  edot: Elastic Distribution of OpenTelemetry
+  edot: Elastic OpenTelemetry
   ecloud:   "Elastic Cloud"
-  edot-cf:   "EDOT Cloud Forwarder"
+  edot-cf:   "Elastic Cloud Forwarder"
   ech:   "Elastic Cloud Hosted"
   ess:   "Elasticsearch Service"
   ece:   "Elastic Cloud Enterprise"

--- a/docs/reference/edot-python/configuration.md
+++ b/docs/reference/edot-python/configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Configuration
-description: Configure the Elastic Distribution of OpenTelemetry Python (EDOT Python) to send data to Elastic.
+description: Configure Elastic OTel Python to send data to Elastic.
 applies_to:
   stack:
   serverless:
@@ -13,13 +13,13 @@ products:
   - id: edot-sdk
 ---
 
-# Configure the EDOT Python agent
+# Configure the Elastic OTel Python agent [configure-the-edot-python-agent]
 
-Configure the {{edot}} Python (EDOT Python) to send data to Elastic.
+Configure Elastic OTel Python to send data to Elastic.
 
 ## Configuration method
 
-Configure the OpenTelemetry SDK through the mechanisms [documented on the OpenTelemetry website](https://opentelemetry.io/docs/zero-code/python/configuration/). EDOT Python is typically configured with `OTEL_*` environment variables defined by the OpenTelemetry spec. For example:
+Configure the OpenTelemetry SDK through the mechanisms [documented on the OpenTelemetry website](https://opentelemetry.io/docs/zero-code/python/configuration/). Elastic OTel Python is typically configured with `OTEL_*` environment variables defined by the OpenTelemetry spec. For example:
 
 ```sh
 export OTEL_RESOURCE_ATTRIBUTES=service.name=<app-name>,deployment.environment.name=<env-name>
@@ -33,7 +33,7 @@ opentelemetry-instrument <command to start your service>
 Because the {{edot}} Python is an extension of OpenTelemetry Python, it supports both:
 
 * [General OpenTelemetry configuration options](#opentelemetry-configuration-options)
-* [Specific configuration options that are only available in EDOT Python](#configuration-options-only-available-in-edot-python)
+* [Specific configuration options that are only available in Elastic OTel Python](#configuration-options-only-available-in-edot-python)
 
 ## Central configuration
 
@@ -44,7 +44,7 @@ product:
   edot_python: preview 1.4.0
 ```
 
-APM Agent Central Configuration lets you configure EDOT Python instances remotely, see [Central configuration docs](opentelemetry://reference/central-configuration.md) for more details.
+APM Agent Central Configuration lets you configure Elastic OTel Python instances remotely, see [Central configuration docs](opentelemetry://reference/central-configuration.md) for more details.
 
 ### Turn on central configuration
 
@@ -94,19 +94,19 @@ export ELASTIC_OTEL_OPAMP_CLIENT_KEY=/path/to/client-key.pem
 
 ### Central configuration settings
 
-You can modify the following settings for EDOT Python through APM Agent Central Configuration:
+You can modify the following settings for Elastic OTel Python through APM Agent Central Configuration:
 
 | Settings      | Description                                  | Type    | Versions |
 |---------------|----------------------------------------------|---------|---------|
-| Logging level | Configure EDOT Python agent logging level.   | Dynamic | {applies_to}`stack: preview 9.1` <br> {applies_to}`edot_python: preview 1.4.0` |
-| Sampling rate | Configure EDOT Python tracing sampling rate. | Dynamic | {applies_to}`stack: preview 9.2` <br> {applies_to}`edot_python: preview 1.7.0` |
-| Deactivate instrumentations | Configure EDOT Python to deactivate tracers for specific instrumentations, supports globbing. Refer to [EDOT Python Supported technologies](/reference/edot-python/supported-technologies.md) for the names of the tracers. | Dynamic | {applies_to}`stack: preview 9.4` <br> {applies_to}`edot_python: preview 1.12.0` |
+| Logging level | Configure Elastic OTel Python agent logging level.   | Dynamic | {applies_to}`stack: preview 9.1` <br> {applies_to}`edot_python: preview 1.4.0` |
+| Sampling rate | Configure Elastic OTel Python tracing sampling rate. | Dynamic | {applies_to}`stack: preview 9.2` <br> {applies_to}`edot_python: preview 1.7.0` |
+| Deactivate instrumentations | Configure Elastic OTel Python to deactivate tracers for specific instrumentations, supports globbing. Refer to [Elastic OTel Python Supported technologies](/reference/edot-python/supported-technologies.md) for the names of the tracers. | Dynamic | {applies_to}`stack: preview 9.4` <br> {applies_to}`edot_python: preview 1.12.0` |
 
 Dynamic settings can be changed without having to restart the application.
 
 ### OpenTelemetry configuration options
 
-EDOT Python supports all configuration options listed in the [OpenTelemetry General SDK Configuration documentation](https://opentelemetry.io/docs/languages/sdk-configuration/general/) and [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python).
+Elastic OTel Python supports all configuration options listed in the [OpenTelemetry General SDK Configuration documentation](https://opentelemetry.io/docs/languages/sdk-configuration/general/) and [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python).
 
 #### TLS configuration for OTLP endpoint
 
@@ -239,15 +239,15 @@ export OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED=true
 
 #### Differences from OpenTelemetry Python
 
-EDOT Python uses different defaults than OpenTelemetry Python for the following configuration options:
+Elastic OTel Python uses different defaults than OpenTelemetry Python for the following configuration options:
 
-| Option | EDOT Python default | OpenTelemetry Python default | Notes |
+| Option | Elastic OTel Python default | OpenTelemetry Python default | Notes |
 |---|---|---|---|
 | `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | `process_runtime,os,telemetry_distro,service_instance,containerid,gcp_resource_detector,aws_ec2,aws_ecs,aws_elastic_beanstalk,azure_app_service,azure_vm,otel` | `otel` | |
 | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | `DELTA` | `CUMULATIVE` | |
 | `OTEL_LOG_LEVEL` | `warn` | | {applies_to}`edot_python: ga 1.9.0` |
 | `OTEL_METRICS_EXEMPLAR_FILTER` | `always_off` | `trace_based` | |
-| `OTEL_TRACES_SAMPLER` | `experimental_composite_parentbased_traceidratio` | `parentbased_always_on` | {applies_to}`edot_python: ga 1.10.0`<br><br>The EDOT Python default was previously `parentbased_traceidratio` {applies_to}`edot_python: ga 1.5-1.9` |
+| `OTEL_TRACES_SAMPLER` | `experimental_composite_parentbased_traceidratio` | `parentbased_always_on` | {applies_to}`edot_python: ga 1.10.0`<br><br>The Elastic OTel Python default was previously `parentbased_traceidratio` {applies_to}`edot_python: ga 1.5-1.9` |
 | `OTEL_TRACES_SAMPLER_ARG` | `1.0` | | {applies_to}`edot_python: ga 1.6.0`|
 
 :::{note}
@@ -258,9 +258,9 @@ EDOT Python uses different defaults than OpenTelemetry Python for the following 
 `OTEL_LOG_LEVEL` accepts the following levels: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `off`.
 :::
 
-### Configuration options only available in EDOT Python
+### Configuration options only available in Elastic OTel Python [configuration-options-only-available-in-edot-python]
 
-`ELASTIC_OTEL_` options are specific to Elastic and will always live in EDOT Python include the following.
+`ELASTIC_OTEL_` options are specific to Elastic and will always live in Elastic OTel Python include the following.
 
 | Option(s) | Default | Description |
 |---|---|---|

--- a/docs/reference/edot-python/index.md
+++ b/docs/reference/edot-python/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Python
-description: The Elastic Distribution of OpenTelemetry Python (EDOT Python) is a customized version of OpenTelemetry Python.
+navigation_title: Elastic OTel Python
+description: The Elastic OTel Python is a customized version of OpenTelemetry Python.
 applies_to:
   stack:
   serverless:
@@ -13,26 +13,26 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Python
+# Elastic OTel Python [elastic-distribution-of-opentelemetry-python]
 
-The [{{edot}} (EDOT) Python](https://github.com/elastic/elastic-otel-python) is a customized version of [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python), configured for the best experience with Elastic Observability. 
+The [Elastic OTel Python](https://github.com/elastic/elastic-otel-python) is a customized version of [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python), configured for the best experience with Elastic Observability. 
 
-Use EDOT Python to start the OpenTelemetry SDK with your Python application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
+Use Elastic OTel Python to start the OpenTelemetry SDK with your Python application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
 
 A goal of this distribution is to avoid introducing proprietary concepts in addition to those defined by the wider OpenTelemetry community. For any additional features introduced, Elastic aims at contributing them back to the OpenTelemetry project.
 
 ## Features
 
-In addition to all the features of the OpenTelemetry Python agent, with EDOT Python you have access to the following:
+In addition to all the features of the OpenTelemetry Python agent, with Elastic OTel Python you have access to the following:
 
 * Improvements and bug fixes contributed by the Elastic team before the changes are available in OpenTelemetry repositories.
 * Optional features that can enhance OpenTelemetry data that is being sent to Elastic.
 * Elastic-specific processors that ensure optimal compatibility when exporting OpenTelemetry signal data to an Elastic backend like an Elastic Observability deployment.
 * Preconfigured collection of tracing and metrics signals, applying some opinionated defaults, such as which sources are collected by default.
-* Compatibility with APM Agent Central Configuration to modify the settings of the EDOT Python agent without having to restart the application.
+* Compatibility with APM Agent Central Configuration to modify the settings of the Elastic OTel Python agent without having to restart the application.
 
 Follow the step-by-step instructions in [Setup](/reference/edot-python/setup/index.md) to get started.
 
 ## Release notes
 
-For the latest release notes, including known issues, deprecations, and breaking changes, refer to [EDOT Python release notes](/release-notes/index.md)
+For the latest release notes, including known issues, deprecations, and breaking changes, refer to [Elastic OTel Python release notes](/release-notes/index.md)

--- a/docs/reference/edot-python/migration.md
+++ b/docs/reference/edot-python/migration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Migration
-description: Migrate from the Elastic APM Python agent to the Elastic Distribution of OpenTelemetry Python (EDOT Python).
+description: Migrate from the Elastic APM Python agent to Elastic OTel Python.
 applies_to:
   stack:
   serverless:
@@ -14,11 +14,11 @@ products:
   - id: apm-agent
 ---
 
-# Migrate to EDOT Python from the Elastic {{product.apm}} Python agent
+# Migrate to Elastic OTel Python from the Elastic {{product.apm}} Python agent [migrate-to-edot-python-from-the-elastic-apm-python-agent]
 
-Learn the differences between the [Elastic {{product.apm}} Python agent](apm-agent-python://reference/index.md) and the {{edot}} Python (EDOT Python).
+Learn the differences between the [Elastic {{product.apm}} Python agent](apm-agent-python://reference/index.md) and Elastic OTel Python.
 
-Follow the steps to migrate your instrumentation and settings. For step-by-step instructions on setting up EDOT Python refer to [Setup](/reference/edot-python/setup/index.md).
+Follow the steps to migrate your instrumentation and settings. For step-by-step instructions on setting up Elastic OTel Python refer to [Setup](/reference/edot-python/setup/index.md).
 
 ## Migration steps
 
@@ -26,23 +26,23 @@ Follow these steps to migrate:
 
 1. Remove any configuration and setup code needed by Elastic {{product.apm-agent-python}} from your application source code.
 2. Migrate any usage of Elastic {{product.apm-agent-python}} API to manual instrumentation with OpenTelemetry API in the application source code.
-3. Follow the [setup documentation](setup/index.md) on to install and configure EDOT Python.
+3. Follow the [setup documentation](setup/index.md) on to install and configure Elastic OTel Python.
 
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-python-migrate
 
-Use this skill to migrate from the Elastic APM Python agent to EDOT Python.
+Use this skill to migrate from the Elastic APM Python agent to Elastic OTel Python.
 :::
 
 ## Configuration mapping
 
-The following are Elastic {{product.apm}} Python agent settings that you can migrate to EDOT Python.
+The following are Elastic {{product.apm}} Python agent settings that you can migrate to Elastic OTel Python.
 
-### Resource attributes when using the EDOT Collector
+### Resource attributes when using {{agent}} [resource-attributes-when-using-the-edot-collector]
 
-Ingesting OpenTelemetry data directly through {{product.apm-server}} is [no longer supported](opentelemetry://reference/architecture/index.md#limitations). Historically, when ingesting OpenTelemetry data through the Elastic {{product.apm-server}}, unmapped resource attributes were added under `labels.*`. This behavior does not apply when using the EDOT Collector and is not recommended for new deployments. Use the EDOT Collector or Managed OTLP for supported ingestion.
+Ingesting OpenTelemetry data directly through {{product.apm-server}} is [no longer supported](opentelemetry://reference/architecture/index.md#limitations). Historically, when ingesting OpenTelemetry data through the Elastic {{product.apm-server}}, unmapped resource attributes were added under `labels.*`. This behavior does not apply when using {{agent}} and is not recommended for new deployments. Use {{agent}} or Managed OTLP for supported ingestion.
 
-If you rely on specific attribute mappings for querying or filtering in {{product.observability}}, configure explicit attribute processors in the EDOT Collector pipeline.
+If you rely on specific attribute mappings for querying or filtering in {{product.observability}}, configure explicit attribute processors in the {{agent}} pipeline.
 
 ### `api_key`
 
@@ -147,7 +147,7 @@ Refer to [Central configuration](opentelemetry://reference/central-configuration
 
 ### AWS Lambda
 
-A custom lambda layer for the {{edot}} Python is not currently available. Refer to the [Lambda Auto-Instrumentation](https://opentelemetry.io/docs/faas/lambda-auto-instrument/).
+A custom lambda layer for Elastic OTel Python is not currently available. Refer to the [Lambda Auto-Instrumentation](https://opentelemetry.io/docs/faas/lambda-auto-instrument/).
 
 ### Missing instrumentations
 
@@ -167,16 +167,16 @@ The following libraries are currently missing an OpenTelemetry equivalent:
 
 ### Integration with structured logging
 
-EDOT Python lacks a [structlog integration](apm-agent-python://reference/logs.md#structlog) at the moment.
+Elastic OTel Python lacks a [structlog integration](apm-agent-python://reference/logs.md#structlog) at the moment.
 
 ### Span compression
 
-EDOT Python does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
+Elastic OTel Python does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
 
 ### Breakdown metrics
 
-EDOT Python is not sending metrics that power the [Breakdown metrics](docs-content://solutions/observability/apm/metrics.md#_breakdown_metrics).
+Elastic OTel Python is not sending metrics that power the [Breakdown metrics](docs-content://solutions/observability/apm/metrics.md#_breakdown_metrics).
 
 ## Troubleshooting
 
-If you're encountering issues during migration, refer to the [EDOT Python troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/python/index.md).
+If you're encountering issues during migration, refer to the [Elastic OTel Python troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/python/index.md).

--- a/docs/reference/edot-python/overhead.md
+++ b/docs/reference/edot-python/overhead.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Performance overhead
-description: This page explains the performance considerations when instrumenting Python applications with the Elastic Distribution of OpenTelemetry SDK, including impact analysis and mitigation techniques.
+description: This page explains the performance considerations when instrumenting Python applications with the Elastic OTel Python SDK, including impact analysis and mitigation techniques.
 applies_to:
   stack:
   serverless:
@@ -13,11 +13,11 @@ products:
   - id: edot-sdk
 ---
 
-# Performance overhead of the Elastic Distribution of OpenTelemetry Python
+# Performance overhead of Elastic OTel Python [performance-overhead-of-the-elastic-distribution-of-opentelemetry-python]
 
-This page explains the performance considerations when instrumenting Python applications with the Elastic Distribution of OpenTelemetry SDK, including impact analysis and mitigation techniques.
+This page explains the performance considerations when instrumenting Python applications with the Elastic OTel Python SDK, including impact analysis and mitigation techniques.
 
-While designed to have minimal performance overhead, the EDOT Python agent, like any instrumentation agent, executes within the application process and thus has a small influence on the application performance. 
+While designed to have minimal performance overhead, the Elastic OTel Python agent, like any instrumentation agent, executes within the application process and thus has a small influence on the application performance. 
 
 This performance overhead depends on the application's technical architecture, its configuration and environment, and the load. These factors are not easy to reproduce on their own, and all applications are different, so it is not possible to provide a simple answer.
 
@@ -27,7 +27,7 @@ The following numbers are only provided as indicators, and you should not attemp
 
 The following table compares the response times of a sample web application without an agent, with Elastic APM Python Agent and with EDOT Python Agent in two situations: without data loaded and serialized to measure the minimal overhead of agents and with some data loaded and then serialized to provide a more common scenario.
 
-|                                   | No agent  | EDOT Python agent | Elastic APM Python agent |
+|                                   | No agent  | Elastic OTel Python agent | Elastic APM Python agent |
 |-----------------------------------|-----------|-----------------------------|--------------------------|
 | No data: Time taken for tests     | 1.277 s   | 2.215 s                     | 2.313 s                  |
 | Sample data: Time taken for tests | 4.546 s   | 6.401 s                     | 6.159 s                  |

--- a/docs/reference/edot-python/setup/index.md
+++ b/docs/reference/edot-python/setup/index.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Setup
-description: Learn how to set up and configure the Elastic Distribution of OpenTelemetry (EDOT) Python to instrument your application or service.
+description: Learn how to set up and configure Elastic OTel Python to instrument your application or service.
 applies_to:
   stack:
   serverless:
@@ -13,16 +13,16 @@ products:
   - id: edot-sdk
 ---
 
-# Set up the EDOT Python agent
+# Set up the Elastic OTel Python agent [set-up-the-edot-python-agent]
 
-Learn how to set up the {{edot}} (EDOT) Python in various environments, including Kubernetes and others.
+Learn how to set up Elastic OTel Python in various environments, including Kubernetes and others.
 
 Follow these steps to get started.
 
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-python-instrument
 
-Use this skill to instrument Python services with EDOT for tracing, metrics, and logs.
+Use this skill to instrument Python services with Elastic OTel for tracing, metrics, and logs.
 :::
 
 :::{warning}
@@ -32,7 +32,7 @@ Avoid using the Python SDK alongside any other APM agent, including Elastic APM 
 ::::::{stepper}
 
 ::::{step} Install the distribution
-Install EDOT Python by running pip:
+Install Elastic OTel Python by running pip:
 
 ```bash
 pip install elastic-opentelemetry
@@ -40,7 +40,7 @@ pip install elastic-opentelemetry
 ::::
 
 ::::{step} Install the available instrumentation
-EDOT Python doesn't install any instrumentation package by default. Instead, it relies on the `edot-bootstrap` command to scan the installed packages and install the available instrumentation. The following command installs all the instrumentations available for libraries installed in your environment:
+Elastic OTel Python doesn't install any instrumentation package by default. Instead, it relies on the `edot-bootstrap` command to scan the installed packages and install the available instrumentation. The following command installs all the instrumentations available for libraries installed in your environment:
 
 ```bash
 edot-bootstrap --action=install
@@ -51,20 +51,20 @@ Add this command every time you deploy an updated version of your application. A
 :::
 ::::
 
-::::{step} Configure EDOT Python
+::::{step} Configure Elastic OTel Python
 Refer to [Observability quickstart](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) documentation on how to setup your environment.
 
-To configure EDOT Python you need to set a few `OTLP_*` environment variables that are available when running EDOT Python:
+To configure Elastic OTel Python you need to set a few `OTLP_*` environment variables that are available when running Elastic OTel Python:
 
 * `OTEL_RESOURCE_ATTRIBUTES`: Use this to add a `service.name` and `deployment.environment.name`. This makes it easier to recognize your application when reviewing data sent to Elastic.
 
-The following environment variables are not required if you are sending data through a local EDOT Collector but are provided in the Elastic Observability platform onboarding:
+The following environment variables are not required if you are sending data through a local {{agent}} but are provided in the Elastic Observability platform onboarding:
 
 * `OTEL_EXPORTER_OTLP_ENDPOINT`: The full URL of the endpoint where data will be sent.
 * `OTEL_EXPORTER_OTLP_HEADERS`: A comma-separated list of `key=value` pairs that will be added to the headers of every request. This is typically used for authentication information.
 ::::
 
-::::{step} Run EDOT Python
+::::{step} Run Elastic OTel Python
 Wrap your service invocation with `opentelemetry-instrument`, which is the wrapper that provides automatic instrumentation. For example, a web service running with gunicorn might look like this:
 
 ```bash
@@ -72,11 +72,11 @@ opentelemetry-instrument gunicorn main:app
 ```
 ::::
 
-::::{step} Confirm that EDOT Python is working
-To confirm that EDOT Python has successfully connected to Elastic:
+::::{step} Confirm that Elastic OTel Python is working
+To confirm that Elastic OTel Python has successfully connected to Elastic:
 
 1. Go to **Observability** → **Applications** → **Service Inventory**
-2. Find the name of the service to which you just added EDOT Python. It can take several minutes after initializing EDOT Python for the service to show up in this list.
+2. Find the name of the service to which you just added Elastic OTel Python. It can take several minutes after initializing Elastic OTel Python for the service to show up in this list.
 3. Select the name in the list to see trace data.
 
 :::{note}
@@ -88,4 +88,4 @@ There might be no trace data to visualize unless you have invoked your applicati
 
 ## Troubleshooting
 
-For help with common setup issues, refer to the [EDOT Python troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/python/index.md).
+For help with common setup issues, refer to the [Elastic OTel Python troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/python/index.md).

--- a/docs/reference/edot-python/setup/k8s.md
+++ b/docs/reference/edot-python/setup/k8s.md
@@ -13,20 +13,20 @@ products:
   - id: edot-sdk
 ---
 
-# Instrumenting Python applications with EDOT SDKs on Kubernetes
+# Instrumenting Python applications with Elastic OTel SDKs on Kubernetes [instrumenting-python-applications-with-edot-sdks-on-kubernetes]
 
-Learn how to instrument Python applications on Kubernetes using the OpenTelemetry Operator, the {{edot}} (EDOT) Collector, and the EDOT Python SDK.
+Learn how to instrument Python applications on Kubernetes using the OpenTelemetry Operator, the {{agent}}, and the Elastic OTel Python SDK.
 
-- For general knowledge about the EDOT Python SDK, refer to the [EDOT Python Intro page](/reference/edot-python/index.md).
+- For general knowledge about the Elastic OTel Python SDK, refer to the [Elastic OTel Python Intro page](/reference/edot-python/index.md).
 - For Python auto-instrumentation specifics, refer to [OpenTelemetry Operator Python auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#python).
-- To manually instrument your Python application code (by customizing spans and metrics), refer to [EDOT Python manual instrumentation](/reference/edot-python/setup/manual-instrumentation.md).
+- To manually instrument your Python application code (by customizing spans and metrics), refer to [Elastic OTel Python manual instrumentation](/reference/edot-python/setup/manual-instrumentation.md).
 - For general information about instrumenting applications on Kubernetes, refer to [instrumenting applications on Kubernetes](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md).
 
 ## Supported environments and configuration
 
 The following environments and configurations are supported:
 
-- EDOT Python container image supports `glibc` and `musl` based auto-instrumentation for Python 3.12.
+- Elastic OTel Python container image supports `glibc` and `musl` based auto-instrumentation for Python 3.12.
 - `musl` based containers instrumentation requires an [extra annotation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#annotations-python-musl) and operator v0.113.0+.
 - To turn on logs auto-instrumentation, refer to [auto-instrument python logs](https://opentelemetry.io/docs/kubernetes/operator/automatic/#auto-instrumenting-python-logs).
 - To turn on specific instrumentation libraries, refer to [excluding auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#python-excluding-auto-instrumentation).

--- a/docs/reference/edot-python/setup/manual-instrumentation.md
+++ b/docs/reference/edot-python/setup/manual-instrumentation.md
@@ -13,11 +13,11 @@ products:
   - id: edot-sdk
 ---
 
-# Manual instrumentation using the Elastic Distribution of OpenTelemetry Python
+# Manual instrumentation using Elastic OTel Python [manual-instrumentation-using-the-elastic-distribution-of-opentelemetry-python]
 
-Learn how to manually instrument Python applications using the {{edot}} Python SDK to add spans, metrics, and custom attributes. The following instructions require auto-instrumentation with OpenTelemetry to have been added to your application per [Setup](/reference/edot-python/setup/index.md).
+Learn how to manually instrument Python applications using the Elastic OTel Python SDK to add spans, metrics, and custom attributes. The following instructions require auto-instrumentation with OpenTelemetry to have been added to your application per [Setup](/reference/edot-python/setup/index.md).
 
-## Configure EDOT Python
+## Configure Elastic OTel Python [configure-edot-python]
 
 Refer to our [Setup](/reference/edot-python/setup/index.md) page for more details.
 
@@ -89,14 +89,14 @@ def hello():
     return f"Hello {choice}!"
 ```
 
-## Confirm that EDOT Python is working
+## Confirm that Elastic OTel Python is working [confirm-that-edot-python-is-working]
 
-To confirm that EDOT Python has successfully connected to Elastic:
+To confirm that Elastic OTel Python has successfully connected to Elastic:
 
 1. Go to **Observability** → **Applications** → **Service Inventory**
-1. Find the name of the service to which you just added EDOT Python. It can take several minutes after initializing EDOT Python for the service to show up in this list.
+1. Find the name of the service to which you just added Elastic OTel Python. It can take several minutes after initializing Elastic OTel Python for the service to show up in this list.
 1. Select the name in the list to see trace data.
 
 :::{note}
-There might be no trace data to visualize unless you have used your application since initializing EDOT Python.
+There might be no trace data to visualize unless you have used your application since initializing Elastic OTel Python.
 :::

--- a/docs/reference/edot-python/supported-technologies.md
+++ b/docs/reference/edot-python/supported-technologies.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Supported Technologies
-description: Technologies Supported by the EDOT Python SDK.
+description: Technologies Supported by the Elastic OTel Python SDK.
 applies_to:
   stack:
   serverless:
@@ -13,9 +13,9 @@ products:
   - id: edot-sdk
 ---
 
-# Technologies supported by EDOT Python
+# Technologies supported by Elastic OTel Python [technologies-supported-by-edot-python]
 
-EDOT Python is a [distribution](https://opentelemetry.io/docs/concepts/distributions/) of OpenTelemetry Python. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies of the OpenTelemetry Python.
+Elastic OTel Python is a [distribution](https://opentelemetry.io/docs/concepts/distributions/) of OpenTelemetry Python. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies of the OpenTelemetry Python.
 
 :::{note}
 **Understanding auto-instrumentation scope**
@@ -32,15 +32,15 @@ If your application uses technologies not covered by auto-instrumentation, you h
 2. **Manual instrumentation** — Use the [OpenTelemetry API](https://opentelemetry.io/docs/languages/python/instrumentation/) to add custom spans, metrics, and logs for unsupported components.
 :::
 
-## EDOT Collector and Elastic Stack versions
+## {{agent}} and Elastic Stack versions [edot-collector-and-elastic-stack-versions]
 
-EDOT Python sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of the EDOT Collector, for full support use either [EDOT Collector](elastic-agent://reference/edot-collector/index.md) versions 9.x or {{serverless-full}} for OTLP ingest.
+Elastic OTel Python sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of {{agent}}, for full support use either [{{agent}}](elastic-agent://reference/edot-collector/index.md) versions 9.x or {{serverless-full}} for OTLP ingest.
 
 :::{note}
-Ingesting data from EDOT SDKs through EDOT Collector 9.x into Elastic Stack versions 8.18+ is supported.
+Ingesting data from Elastic OTel SDKs through {{agent}} 9.x into Elastic Stack versions 8.18+ is supported.
 :::
 
-Refer to [EDOT SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
+Refer to [Elastic OTel SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
 
 ## Python versions
 

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Breaking changes 
-description: Breaking changes for Elastic Distribution of OpenTelemetry .
+description: Breaking changes for Elastic OTel Python.
 applies_to:
   stack:
   serverless:
@@ -11,9 +11,9 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Python breaking changes [edot-python-breaking-changes]
+# Elastic OTel Python breaking changes [edot-python-breaking-changes]
 
-Breaking changes can impact your Elastic applications, potentially disrupting normal operations. Before you upgrade, carefully review the Elastic Distribution of OpenTelemetry Python breaking changes and take the necessary steps to mitigate any issues.
+Breaking changes can impact your Elastic applications, potentially disrupting normal operations. Before you upgrade, carefully review the Elastic OTel Python breaking changes and take the necessary steps to mitigate any issues.
 
 % ## Next version [edot-python-X.X.X-breaking-changes]
 

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Deprecations 
-description: Deprecations for Elastic Distribution of OpenTelemetry Python.
+description: Deprecations for Elastic OTel Python.
 applies_to:
   stack:
   serverless:
@@ -11,11 +11,11 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Python deprecations [edot-python-deprecations]
+# Elastic OTel Python deprecations [edot-python-deprecations]
 
 Over time, certain Elastic functionality becomes outdated and is replaced or removed. To help with the transition, Elastic deprecates functionality for a period before removal, giving you time to update your applications.
 
-Review the deprecated functionality for Elastic Distribution of OpenTelemetry Python. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
+Review the deprecated functionality for Elastic OTel Python. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
 
 % ## Next version [edot-python-X.X.X-deprecations]
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Python
-description: Release notes for Elastic Distribution of OpenTelemetry Python.
+navigation_title: Elastic OTel Python
+description: Release notes for Elastic OTel Python.
 applies_to:
   stack:
   serverless:
@@ -11,9 +11,9 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Python release notes [edot-python-release-notes]
+# Elastic OTel Python release notes [edot-python-release-notes]
 
-Review the changes, fixes, and more in each version of Elastic Distribution of OpenTelemetry Python.
+Review the changes, fixes, and more in each version of Elastic OTel Python.
 
 To check for security updates, go to [Security announcements for the Elastic stack](https://discuss.elastic.co/c/announcements/security-announcements/31).
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Known issues 
-description: Known issues for Elastic Distribution of OpenTelemetry Python.
+description: Known issues for Elastic OTel Python.
 applies_to:
   stack:
   serverless:
@@ -11,6 +11,6 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Python known issues
+# Elastic OTel Python known issues [elastic-distribution-of-opentelemetry-python-known-issues]
 
 No known issues.


### PR DESCRIPTION
## Summary

- Prose-only rebrand across all `docs/` markdown files and `docs/docset.yml` for the 9.5 GA release (July 28, 2026).
- `EDOT Python` → `Elastic OTel Python` throughout; `EDOT Collector` → `{{agent}}`; `EDOT SDKs` → `Elastic OTel SDKs`; `Elastic Distribution of OpenTelemetry` → `Elastic OpenTelemetry` (generic) or `Elastic OTel Python` (SDK-specific).
- Machine identifiers are **unchanged**: URL path slugs (`edot-python/`), `applies_to` product IDs (`edot_python`, `edot-sdk`), env vars, binary names (`edot-bootstrap`), package names, and non-mermaid code blocks.
- Old heading slugs preserved via explicit bracket anchors (e.g. `[configure-the-edot-python-agent]`).
- Release-note changelog body entries left intact as historical record for pre-9.5 versions.

## Held as draft for coordinated merge on July 28 2026 9.5 GA

This PR is intentionally kept as a draft and should not be merged before the coordinated 9.5 GA release date.

## Test plan

- [ ] Verify rendered docs show new brand name in navigation and headings
- [ ] Confirm old anchor IDs still resolve (e.g. `#configure-the-edot-python-agent`)
- [ ] Check that `applies_to` product badges still render correctly (IDs unchanged)
- [ ] Coordinate merge with other EDOT rebrand PRs on July 28 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)