### PR TITLE
operator/Dockerfile: bump chainguard-base to e8b23e9

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON_GLIBC_IMAGE="docker.elastic.co/wolfi/python"
 ARG PYTHON_GLIBC_IMAGE_VERSION="v3.12.14-r2-dev@sha256:139677a4ac6056f94a458852a3ea0e77faba59129636dd4c52f756050f5993de"
 
 ARG IMAGE="docker.elastic.co/wolfi/chainguard-base"
-ARG IMAGE_VERSION="latest@sha256:667b045faaff38dabac9960a69aca1af3ddec227e1ba50324ed22fb0b7ef0a41"
+ARG IMAGE_VERSION="latest@sha256:e8b23e9bccb0559f1a5cc3ee7c1e7ba3cd44eab5738897b43d7145f4cea5ce76"
 
 FROM ${PYTHON_GLIBC_IMAGE}:${PYTHON_GLIBC_IMAGE_VERSION} AS build
 


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump chainguard-base image to latest.

## Related issues