### PR TITLE
Retarget EDOT Python agent-skill callouts to observability-onboarding

### DIFF
--- a/docs/reference/edot-python/migration.md
+++ b/docs/reference/edot-python/migration.md
@@ -29,7 +29,7 @@ Follow these steps to migrate:
 3. Follow the [setup documentation](setup/index.md) on to install and configure EDOT Python.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills@observability-onboarding
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to migrate from the Elastic APM Python agent to EDOT Python.
 :::

--- a/docs/reference/edot-python/migration.md
+++ b/docs/reference/edot-python/migration.md
@@ -28,12 +28,6 @@ Follow these steps to migrate:
 2. Migrate any usage of Elastic {{product.apm-agent-python}} API to manual instrumentation with OpenTelemetry API in the application source code.
 3. Follow the [setup documentation](setup/index.md) on to install and configure EDOT Python.
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-python-migrate
-
-Use this skill to migrate from the Elastic APM Python agent to EDOT Python.
-:::
-
 ## Configuration mapping
 
 The following are Elastic {{product.apm}} Python agent settings that you can migrate to EDOT Python.

--- a/docs/reference/edot-python/migration.md
+++ b/docs/reference/edot-python/migration.md
@@ -28,6 +28,12 @@ Follow these steps to migrate:
 2. Migrate any usage of Elastic {{product.apm-agent-python}} API to manual instrumentation with OpenTelemetry API in the application source code.
 3. Follow the [setup documentation](setup/index.md) on to install and configure EDOT Python.
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills@observability-onboarding
+
+Use this skill to migrate from the Elastic APM Python agent to EDOT Python.
+:::
+
 ## Configuration mapping
 
 The following are Elastic {{product.apm}} Python agent settings that you can migrate to EDOT Python.

--- a/docs/reference/edot-python/setup/index.md
+++ b/docs/reference/edot-python/setup/index.md
@@ -19,12 +19,6 @@ Learn how to set up the {{edot}} (EDOT) Python in various environments, includin
 
 Follow these steps to get started.
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-python-instrument
-
-Use this skill to instrument Python services with EDOT for tracing, metrics, and logs.
-:::
-
 :::{warning}
 Avoid using the Python SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::

--- a/docs/reference/edot-python/setup/index.md
+++ b/docs/reference/edot-python/setup/index.md
@@ -19,6 +19,12 @@ Learn how to set up the {{edot}} (EDOT) Python in various environments, includin
 
 Follow these steps to get started.
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills@observability-onboarding
+
+Use this skill to instrument Python services with EDOT for tracing, metrics, and logs.
+:::
+
 :::{warning}
 Avoid using the Python SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::

--- a/docs/reference/edot-python/setup/index.md
+++ b/docs/reference/edot-python/setup/index.md
@@ -20,7 +20,7 @@ Learn how to set up the {{edot}} (EDOT) Python in various environments, includin
 Follow these steps to get started.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills@observability-onboarding
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to instrument Python services with EDOT for tracing, metrics, and logs.
 :::


### PR DESCRIPTION
## Summary

elastic/agent-skills [v0.6.0](https://github.com/elastic/agent-skills/releases/tag/v0.6.0) removed `edot-python-instrument` and `edot-python-migrate`. Those skills now live in `observability-onboarding`, which still covers both paths for Python: attach EDOT when no classic APM agent is present, and migrate off the Elastic APM Python agent. The attach method (`opentelemetry-instrument` plus `edot-bootstrap`), environment variables, and do-not-reuse-APM-Server-URL guidance match the old skills.

This PR points the setup and migration `{agent-skill}` callouts at the GitHub folder [`skills/observability/onboarding`](https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding). Page-specific body text is unchanged so setup still orients to instrument, and migration still orients to migrate.

These companion docs use a `/tree/main/skills/...` URL instead of the `repo@skill` form. The `@` URLs 404 if opened as GitHub links, and in these EDOT repos they also break the link the directive embeds.

Companion to elastic/docs-content#8227. Tracked in elastic/docs-content#8230.

## Test plan

- [ ] Preview the setup and migration pages and confirm each callout links to the `observability/onboarding` skill folder.
- [ ] Confirm surrounding setup and migration steps are unchanged.
