### PR TITLE
Retarget agent-skill callouts to observability/onboarding

### DIFF
--- a/docs/reference/edot-python/migration.md
+++ b/docs/reference/edot-python/migration.md
@@ -29,7 +29,7 @@ Follow these steps to migrate:
 3. Follow the [setup documentation](setup/index.md) on to install and configure EDOT Python.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-python-migrate
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to migrate from the Elastic APM Python agent to EDOT Python.
 :::

--- a/docs/reference/edot-python/setup/index.md
+++ b/docs/reference/edot-python/setup/index.md
@@ -20,7 +20,7 @@ Learn how to set up the {{edot}} (EDOT) Python in various environments, includin
 Follow these steps to get started.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-python-instrument
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to instrument Python services with EDOT for tracing, metrics, and logs.
 :::


### PR DESCRIPTION
## Summary

The `edot-python-instrument` and `edot-python-migrate` skills were removed in [elastic/agent-skills](https://github.com/elastic/agent-skills) `v0.6.0` and consolidated into `observability/onboarding`, which now covers both instrument and migrate for EDOT Python. The two `{agent-skill}` callouts in the EDOT Python docs still pointed at the removed skill folders, so the links they embed now 404.

This retargets both callouts to `skills/observability/onboarding`.

## Changes

- `docs/reference/edot-python/setup/index.md`: `observability/edot-python-instrument` -> `observability/onboarding`
- `docs/reference/edot-python/migration.md`: `observability/edot-python-migrate` -> `observability/onboarding`

## Context

Companion to elastic/docs-content#8230. The equivalent EDOT Java and EDOT .NET callouts already point to `observability/onboarding`, so no changes are needed there.

Made with [Cursor](https://cursor.com)